### PR TITLE
docs: revamp why-does-message-parsing-fail page

### DIFF
--- a/incidents/acknowledge-timeout.md
+++ b/incidents/acknowledge-timeout.md
@@ -1,34 +1,23 @@
 ---
-description: >-
-  Set a timeout for when an incident is acknowledged but not resolved in the
-  given time frame. Acknowledge timeout helps your team by reminding you of
-  incidents in non-resolved state
+description: Acknowledge timeout automatically moves an acknowledged incident back to triggered state if it isn't resolved within a set time.
 ---
 
 # Acknowledge timeout
 
-## What is acknowledge timeout?
+Acknowledge timeout is a time limit you set on an integration. If an acknowledged incident isn't resolved within that window, Spike moves it back to triggered state and resumes alerting. This is useful when someone acknowledges an incident but gets pulled into other work before resolving it.
 
-After acknowledging the incident, if it is not resolved in given amount of time then it will return to **triggered state**. Escalations and alerts will resume again.
+<figure><img src="../.gitbook/assets/ack-timeout.png" alt="Acknowledge timeout setting"><figcaption><p>Set acknowledge timeout in minutes on any integration.</p></figcaption></figure>
 
-Many-a-times, you or your team-mate would acknowledge an incident but never get around to resolving it for multitude of reasons. This is where the **acknowledge timeout** feature comes in handy.&#x20;
+## What timeout should you set?
 
-You can set acknowledge timeout **in minutes** to all of your new and existing integrations by editing a service or adding a new service.&#x20;
+It depends on how critical the integration is. A shorter timeout means faster re-alerting on unresolved incidents.
 
-![Acknowledge timeout](../.gitbook/assets/ack-timeout.png)
+- **Critical integrations** — 20 minutes
+- **Severe but non-critical integrations** — 60 minutes
+- **Non-critical integrations** — leave it blank
 
-### What is an ideal Acknowledge timeout?
+You don't need a timeout on every integration.
 
-This really depends on the integration. The more critical it is the shorter the timeout should be.&#x20;
-
-_Here's what we recommend -_
-
-1. Critical integration - **20 minutes**
-2. Severe but not critical integration - **60 minutes**
-3. Non-severe and non-critical integration - **Leave it blank.**
-
-You don't need an Acknowledge timeout for _every integration._&#x20;
-
-{% hint style="info" %}
-Please make sure to keep a generous timeout and **avoid keeping short times like 5 or 10 minutes**. Keeping short timeouts will end up in way too many alerts you did rather ignore.
+{% hint style="warning" %}
+Avoid short timeouts like 5 or 10 minutes. They generate more alerts than your team can act on and increase alert fatigue.
 {% endhint %}

--- a/incidents/grouping-incidents.md
+++ b/incidents/grouping-incidents.md
@@ -1,15 +1,17 @@
 ---
-description: Repeated incidents will be grouped together.
+description: Spike automatically groups repeated incidents so you can see how often an issue recurs and when it first appeared.
 ---
 
 # Grouping incidents
 
-## Group repeated incidents
+When the same incident fires multiple times, Spike groups the repeats under the original incident rather than creating new ones. This keeps your dashboard clean and gives you a clear picture of how often an issue is recurring.
 
-Spike supports automatic grouping of incidents which will be repeated. It helps give you perspective on how many times has this incident been repeated. Below is an example -
+<figure><img src="../.gitbook/assets/image (14) (1) (1).png" alt="Grouped incidents on Spike"><figcaption><p>Repeated incidents are grouped under the original with a repeat count.</p></figcaption></figure>
 
-![This "Parallel write .." has been grouped to give you some insights](<../.gitbook/assets/image (14) (1) (1).png>)
+Each grouped incident shows:
 
-### Use cases
+- How many times it has repeated
+- When it first occurred
+- When it last occurred
 
-Grouping incidents gives your context. It gives you insights of how many times it has repeated along with it's first occurrence and the last occurrence of this incident. This will help you identify if this is an incident that is truly affecting your customers and how many times it has affected in the past too. Given these stats, you should be able to prioritise this incident and work on it.
+This helps you judge whether an issue is a one-off or a pattern. If an incident has repeated dozens of times, it's likely affecting your customers and worth prioritizing over something that fired once.

--- a/incidents/grouping-incidents.md
+++ b/incidents/grouping-incidents.md
@@ -4,7 +4,7 @@ description: Spike automatically groups repeated incidents so you can see how of
 
 # Grouping incidents
 
-When the same incident fires multiple times, Spike groups the repeats under the original incident rather than creating new ones. This keeps your dashboard clean and gives you a clear picture of how often an issue is recurring.
+When the same incident fires multiple times, Spike groups them under the original incident rather than creating new ones. This keeps your dashboard clean and gives you a clear picture of how often an issue is recurring.
 
 <figure><img src="../.gitbook/assets/image (14) (1) (1).png" alt="Grouped incidents on Spike"><figcaption><p>Repeated incidents are grouped under the original with a repeat count.</p></figcaption></figure>
 
@@ -13,5 +13,6 @@ Each grouped incident shows:
 - How many times it has repeated
 - When it first occurred
 - When it last occurred
+- When each recurrence happened
 
 This helps you judge whether an issue is a one-off or a pattern. If an incident has repeated dozens of times, it's likely affecting your customers and worth prioritizing over something that fired once.

--- a/incidents/how-to-change-incident-status.md
+++ b/incidents/how-to-change-incident-status.md
@@ -1,10 +1,10 @@
 ---
-description: You can change an incident's status from the dashboard, a phone call, Slack, email, SMS, or mobile.
+description: You can change an incident's status from all alerting channels without having to come to Spike.
 ---
 
 # How to change incident status
 
-You can change an incident's status from multiple places: the dashboard, a phone call, Slack, email, SMS, or mobile.
+You can change an incident's status from all alerting channels without having to come to Spike.
 
 ## From the dashboard
 

--- a/incidents/how-to-change-incident-status.md
+++ b/incidents/how-to-change-incident-status.md
@@ -1,80 +1,59 @@
 ---
-description: >-
-  Responders can choose to change incident status on phone alerts, Slack and on
-  the dashboard.
+description: You can change an incident's status from the dashboard, a phone call, Slack, email, SMS, or mobile.
 ---
 
-# How to change incident status?
+# How to change incident status
+
+You can change an incident's status from multiple places: the dashboard, a phone call, Slack, email, SMS, or mobile.
 
 ## From the dashboard
 
-![Select one or more incidents](../.gitbook/assets/incident-status-change-new.png)
+<figure><img src="../.gitbook/assets/incident-status-change-new.png" alt="Select one or more incidents on the dashboard"><figcaption><p>Select incidents and change their status from the dashboard.</p></figcaption></figure>
 
-You will see open incidents on the [dashboard](https://app.spike.sh). Select a single incident with the checkbox on the left-hand side and hit the **Acknowledge** button on top. Similarly, you can choose to **Resolve** by using the adjacent button.
+Open the [dashboard](https://app.spike.sh) to see all open incidents. Select an incident using the checkbox on the left, then click **Acknowledge** or **Resolve** at the top.
 
 ### Multiple incidents
 
-Alternatively, you can choose multiple incidents to change status by selecting each incident or use the dropdown to quickly select all incidents that match the criteria.
+Select multiple incidents using the checkboxes, or use the dropdown to select all incidents matching a specific criteria. Then apply the status change in bulk.
 
-## From phone call
+## From a phone call
 
+<figure><img src="../.gitbook/assets/phone.png" alt="Take actions on incidents from a phone call"><figcaption><p>Use keypresses during a phone alert to change incident status.</p></figcaption></figure>
 
+During a [phone alert](../alerts/phone.md), press a key to take action immediately:
 
-![Take actions on incidents from the phone call](../.gitbook/assets/phone.png)
+1. **Press 4** to acknowledge
+2. **Press 6** to resolve
+3. **Press 9** to escalate
 
-On the phone alert, you can take immediate actions by -&#x20;
+You'll hear a voice confirmation on the same call once the status changes.
 
-1. **Press 4 to Acknowledge**
-2. **Press 6 to Resolve**
-3. **Press 9 to Escalate**
+## From Slack
 
-Phone calls are restricted to 420 characters which we believe should suffice to give you the context of the incident.&#x20;
+<figure><img src="../.gitbook/assets/slack-gif.gif" alt="Acknowledge and resolve incidents from Slack"><figcaption><p>Slack alerts include Acknowledge and Resolve buttons.</p></figcaption></figure>
 
-{% hint style="info" %}
-You will get a voice confirmation on the same call upon incident status change
-{% endhint %}
+Every [Slack alert](../alerts/slack.md) includes **Acknowledge** and **Resolve** buttons. When you change the status, all related Slack messages update to reflect it. This applies regardless of whether the change was made via phone, email, SMS, or the dashboard.
 
-## **From Slack**
+## From email
 
-All alerts on Slack will have actionable buttons to **Acknowledge** and **Resolve** incidents.
+Reply to a [Spike email alert](../alerts/email.md) with one of the following:
 
-![](../.gitbook/assets/slack-gif.gif)
+1. **#ack** to acknowledge
+2. **#res** to resolve
 
-{% hint style="info" %}
-Upon status change, the relevant Slack messages will update to reflect them. This also applies if anyone changes the status via Phone, Email, SMS, or from the Dashboard too.&#x20;
-{% endhint %}
+No confirmation is sent after the status change.
 
-## **From Email**
+## From SMS
 
-Use the following actions to change incident status directly from email by replying -&#x20;
+Send an SMS from your registered phone number to change status. You don't need to reply to a Spike message — just send a new one:
 
-1. **#res** to resolve
-2. **#ack** to acknowledge
+1. **#\<incident\_id> ack** to acknowledge (example: `#1226 ack`)
+2. **#\<incident\_id> res** to resolve (example: `#2071 res`)
 
-{% hint style="info" %}
-Upon status change, we do not send a confirmation
-{% endhint %}
+This works even if [SMS](../alerts/sms.md) is not in your escalation policy. Spike processes the action as long as you send from your registered number.
 
-## **From SMS**
+## From mobile
 
-Send Spike.sh an SMS from your registered phone number to change incident status.&#x20;
+The dashboard and incident detail pages are mobile-compatible. Visit [app.spike.sh](https://app.spike.sh) on your mobile browser to view open incidents and change their status.
 
-1. **#\<incident\_id> res** to resolve. (example: #2071 res)
-2. **#\<incident\_id> ack** to acknowledge. (example: #1226 ack)
-
-The SMS action doesn't depend on replying to our message. It only relies on you sending us a message. This means if you don't have SMS in your escalation policy and then choose to perform the above action, it would still work.&#x20;
-
-{% hint style="info" %}
-Upon status change, we do not send a confirmation
-{% endhint %}
-
-## From mobile website
-
-Our dashboard page and incident details page are mobile compatible. You can check open incidents and relevant incidents on your mobile and change incident statuses.&#x20;
-
-![Incident page on mobile](<../.gitbook/assets/image (73).png>)
-
-{% hint style="info" %}
-visit [https://app.spike.sh](https://app.spike.sh) on mobile to access the dashboard.
-{% endhint %}
-
+<figure><img src="../.gitbook/assets/image (73).png" alt="Incident page on mobile"><figcaption><p>View and manage incidents from your mobile browser.</p></figcaption></figure>

--- a/incidents/incident-lifecycle.md
+++ b/incidents/incident-lifecycle.md
@@ -1,45 +1,36 @@
 ---
-description: Lifecycle of an incident.
+description: The incident lifecycle covers the stages an incident moves through, from the moment it's triggered to when it's resolved.
 ---
 
 # Incident lifecycle
 
-## Incident lifecycle
+Every incident on Spike moves through a defined set of stages. Understanding this flow helps you configure escalation policies, acknowledge timeouts, and alert channels to match how your team actually responds.
 
-Incidents can have one of these statuses -
+<figure><img src="../.gitbook/assets/Incident lifecycle.png" alt="Incident lifecycle on Spike"><figcaption><p>The stages of an incident on Spike.</p></figcaption></figure>
 
-1. **Triggered**
-2. **Acknowledged**
-3. **Resolved**
+## 1. Incident creation
 
-_Learn more about what these states in the next page_
+An incident is created when a connected integration sends a webhook to Spike. Before creating a new incident, Spike checks whether an open incident already exists for that integration.
 
-![](<../.gitbook/assets/Incident lifecycle.png>)
-
-### 1. Triggering incidents
-
-Your added integrations will create an incident on Spike. Every integration on one or more services are treated uniquely. This would mean that you can have multiple AWS integrations and they will all be treated uniquely to make sure that incidents are triggered.
-
-Before the incident is created, Spike checks for similar incidents for this integration. If it exists then _a new incident is not created but an event is logged for the same incident which is not resolved._
+- If one exists, Spike logs the new event under the existing incident instead of creating a duplicate.
+- If no open incident exists, Spike creates a new one and starts the escalation process.
 
 {% hint style="info" %}
-**Avoiding duplication of incidents**.
-
-Similar incidents in resolved state are ignored. Only the incidents which are **open (acknowledged or triggered state)** will be checked.
+Only open incidents (triggered or acknowledged) are checked for duplicates. Resolved incidents are ignored.
 {% endhint %}
 
-### 2. Automatic escalations
+## 2. Incident escalation
 
-On Spike, you have the freedom to assign a separate escalation policy to each of your integration. This gives you the flexibility to operate with ease knowing which alerts to prioritise over others.
+Once an incident is created, Spike works through the [escalation policy](../escalations/introduction-to-escalations.md) attached to that integration. Alerts go out to the first set of responders in the policy. Spike waits for the duration configured in the escalation policy. If no one acknowledges or resolves the incident in that time, Spike moves to the next level and alerts the next set of responders.
 
-![Example escalation policy on spike.sh](<../.gitbook/assets/screenshot-2020-06-24-at-10.48.37-am (1).png>)
+Each integration can have its own escalation policy. This lets you set different alert priorities across services.
 
-Spike alerts based on the escalation policy. For the newly created incident, the first alert is sent in the order of responders in the policy. In the above example, the first alert is being sent to the **Slack channel #incidents** along with alerting dev member Kaushik and email to another member.
+## 3. Incident acknowledgment
 
-Spike waits for 5 minutes for the any of the responders to acknowledge or resolve the incident. If there is no action taken, spike automatically escalates and alerts the responders on the next level.
+When a responder acknowledges the incident, Spike pauses the escalation policy and stops sending alerts. You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration: a time limit that moves the incident back to triggered and resumes alerting if it hasn't been resolved in time.
 
-In the above examples, there are 2 responders who will be alerted via phone, also at the same time we alert to **Slack channel #dev-team**.
+## 4. Incident resolution
 
-### 3. Acknowledge timeout
+Once the issue is fixed, mark the incident as resolved. Spike stops all alerts and resets the escalation policy. If a new incident comes in for the same integration, the process starts again from the beginning.
 
-For every integration, you can choose a set a timeout for incidents acknowledged but not resolved. After this timeout, Spike resumes the escalations and start sending alerts to the next escalation level. If it's the end of escalation then it's repeated automatically.
+See [incident statuses](incident-statuses.md) for a full reference on each status.

--- a/incidents/incident-lifecycle.md
+++ b/incidents/incident-lifecycle.md
@@ -27,7 +27,7 @@ Each integration can have its own escalation policy. This lets you set different
 
 ## 3. Incident acknowledgment
 
-When a responder acknowledges the incident, Spike pauses the escalation policy and stops sending alerts. You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration: a time limit that moves the incident back to triggered and resumes alerting if it hasn't been resolved in time.
+When a responder acknowledges the incident, Spike pauses the escalation policy and stops escalating alerts. You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration: a time limit that moves the incident back to triggered and resumes alerting if it hasn't been resolved in time.
 
 ## 4. Incident resolution
 

--- a/incidents/incident-statuses.md
+++ b/incidents/incident-statuses.md
@@ -1,50 +1,25 @@
 ---
-description: >-
-  A status would determine the state of the incident among acknowledged or
-  resolved
+description: Every incident on Spike has one of three statuses: triggered, acknowledged, or resolved. The status determines what Spike does next.
 ---
 
 # Incident statuses
 
-## What are different Incident statuses?
+Every incident on Spike moves through three statuses: triggered, acknowledged, and resolved. The current status determines whether Spike is actively alerting, paused while someone works on a fix, or closed.
 
-There are mainly 3 states -&#x20;
+## Triggered
 
-1. **Triggered 🔥**
-2. **Acknowledged** 👩‍💻
-3. **Resolved** ✅
+An incident enters the triggered state the moment it's created. This means no one has looked at it yet and the problem is unresolved.
 
-### **1. Triggered 🔥**
+In this state, Spike works through the [escalation policy](../escalations/introduction-to-escalations.md) attached to the integration and sends alerts to the designated responders. Alerts continue until someone acknowledges or resolves the incident. Repeat incidents from the same integration are suppressed and logged rather than creating new ones.
 
-Every incident which comes to Spike will be first in the **triggered** state. It would mean that someone will need to look into this and address the problem.
+## Acknowledged
 
-Alerts are sent to members as long as an incident remains in this state.&#x20;
+An acknowledged incident means someone is actively working on a fix. Spike pauses the escalation policy and stops sending alerts.
 
-### 2. Acknowledged 👩‍💻
+Repeat incidents remain suppressed in this state to reduce [alert fatigue](../alerts/personal-alerts-management/README.md). You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration. If the incident isn't resolved within that window, Spike moves it back to triggered and resumes alerting.
 
-An **acknowledged** state of the incident would mean that you have begun to look into the incident. Alternatively, this also means that work to resolve this incident has begun.&#x20;
+## Resolved
 
-In this state, repeat incidents are automatically suppressed and logged reducing alert fatigue.
+A resolved incident means the issue is fixed. Spike stops all alerts and resets the escalation policy.
 
-{% hint style="info" %}
-We highly recommend setting an acknowledge timeout for all your incidents.&#x20;
-{% endhint %}
-
-{% content-ref url="acknowledge-timeout.md" %}
-[acknowledge-timeout.md](acknowledge-timeout.md)
-{% endcontent-ref %}
-
-### 3. Resolved ✅
-
-Once an incident is fixed, you mark it as **resolved**. This is the end state for all incidents.&#x20;
-
-If a similar incident is triggered then a new incident is created.
-
-
-
-
-
-
-
-
-
+If the same integration triggers a new incident after resolution, Spike treats it as a fresh incident and starts the process from the beginning. See [incident lifecycle](incident-lifecycle.md) for the full flow.

--- a/incidents/incident-statuses.md
+++ b/incidents/incident-statuses.md
@@ -8,7 +8,7 @@ Every incident on Spike moves through three statuses: triggered, acknowledged, a
 
 ## Triggered
 
-An incident enters the triggered state the moment it's created. This means no one has looked at it yet and the problem is unresolved.
+An incident enters the triggered state the moment it's triggered. This means no one has looked at it yet and the problem is unresolved.
 
 In this state, Spike works through the [escalation policy](../escalations/introduction-to-escalations.md) attached to the integration and sends alerts to the designated responders. Alerts continue until someone acknowledges or resolves the incident. Repeat incidents from the same integration are suppressed and logged rather than creating new ones.
 

--- a/incidents/incident-statuses.md
+++ b/incidents/incident-statuses.md
@@ -14,7 +14,7 @@ In this state, Spike works through the [escalation policy](../escalations/introd
 
 ## Acknowledged
 
-An acknowledged incident means someone is actively working on a fix. Spike pauses the escalation policy and stops sending alerts.
+An acknowledged incident means someone is actively working on a fix. Spike pauses the escalation policy and stops escalating alerts.
 
 Repeat incidents remain suppressed in this state to reduce [alert fatigue](../alerts/personal-alerts-management/README.md). You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration. If the incident isn't resolved within that window, Spike moves it back to triggered and resumes alerting.
 

--- a/incidents/mute-alerts.md
+++ b/incidents/mute-alerts.md
@@ -1,24 +1,24 @@
 ---
-description: >-
-  Mute all alerts 🚨  (or switch off all alarms) for an incident so you can
-  continue your work fixing it.
+description: Mute alerts on an incident to stop notifications for a set period without resolving it.
 ---
 
 # Mute alerts
 
-## Mute alerts
+Muting stops all alerts for an incident and its repeated occurrences for a set period. The incident stays open and logged. Spike just stops notifying your team about it.
 
-For every **incident** **and it's repeated incidents**, you can choose to mute all alerts for a specific period of time. Following are the time options currently available -
+This is useful for low-priority incidents you're aware of but don't need to act on immediately. Instead of getting alerted repeatedly, you mute it and come back when you're ready.
 
-1. An hour
-2. 10 hours
-3. A day
-4. A week
-5. A month
-6. **Forever** - (_note: be careful with this_)
+<figure><img src="../.gitbook/assets/image (15) (1) (1).png" alt="Mute alerts on an incident"><figcaption><p>Mute alerts on an incident for a set duration.</p></figcaption></figure>
 
-![Mute alerts or switch off alarms](<../.gitbook/assets/image (15) (1) (1).png>)
+## Mute duration options
 
-### Use cases
+- 1 hour
+- 10 hours
+- 1 day
+- 1 week
+- 1 month
+- Forever
 
-Not all incidents are critical, also, not all incidents need to be worked upon instantly. For all those low handing fruits, you can now mute the alerts and just log these incidents on Spike.
+{% hint style="warning" %}
+Use **Forever** carefully. Muting an incident permanently means your team will never be alerted about it again, even if it keeps recurring.
+{% endhint %}

--- a/incidents/priority-and-severity.md
+++ b/incidents/priority-and-severity.md
@@ -1,79 +1,71 @@
 ---
-description: >-
-  Determine and set incident's priority to indicate urgency and severity to
-  indicate possible damage
+description: Priority indicates how urgently an incident needs to be resolved. Severity indicates the degree of damage to your systems.
 ---
 
-# Priority and Severity
+# Priority and severity
 
-Not all incidents are critical or need to be resolved immediately. To help understand an incident better, we bring you two critical components to every incident - **Priority, and Severity**.&#x20;
+Not all incidents need immediate action. Priority and severity give your team two ways to classify an incident: how urgent it is to fix, and how much damage it's causing.
 
 ## Priority
 
-Assign a priority to your incident to indicate the urgency to resolve it. If the incident repeats itself, the set priority will be automatically assigned.
+Priority indicates the urgency to resolve an incident. Available priorities are:
 
-Available priorities are -&#x20;
+- **P1**: Urgent
+- **P2**: High
+- **P3**: Medium
+- **P4**: Low
+- **P5**: Info
 
-* **P1** - Urgent
-* **P2** - High
-* **P3** - Medium
-* **P4** - Low
-* **P5** - Info&#x20;
-
-Setting priority is a great way to indicate to your team the urgency to fix it. Additionally, you can setup alert rules to take actions automatically when the incident repeats itself. \
-\
-**Example:**\
-****P1 **** - Billing service downtime\
-****P2 **** - DB server running out of storage space
+For example, a billing service outage is a P1. A database server running low on storage might be a P2.
 
 ## Severity
 
-Assign severity to indicate the severity of damage to your systems.&#x20;
+Severity indicates the degree of damage to your systems. Available severities are:
 
-Available severities are -
+- **SEV1**: High
+- **SEV2**: Medium
+- **SEV3**: Low
 
-* **SEV1** - High
-* **SEV2** - Medium
-* **SEV3** - Low
+For example, a data leak or full service outage is a SEV1. A degraded non-critical service might be a SEV3.
 
-Data leaks / Website service down is a good example of SEV1 - High severity.
-
-{% hint style="success" %}
-Once set, we will remember the severity and priority when the incident occurs in the future.
+{% hint style="info" %}
+Once you set priority and severity on an incident, Spike remembers them for future occurrences of the same incident.
 {% endhint %}
 
 ## Setting priority and severity
 
-There are multiple ways to assign these properties to an incident.&#x20;
+### From the dashboard
 
-### From dashboard
+Select one or more incidents. The priority, severity, and mute options appear at the top of the list.
 
-Select incidents and the options for priority, severity, and mute will be available for you.&#x20;
+<figure><img src="../.gitbook/assets/Priority on dashboard.png" alt="Set priority on multiple incidents from the dashboard"><figcaption><p>Select incidents from the dashboard to set priority and severity in bulk.</p></figcaption></figure>
 
+### From the incident page
 
+Open any incident to find the priority and severity options on the incident detail page.
 
-![Set priority on multiple incidents](<../.gitbook/assets/Priority on dashboard.png>)
+<figure><img src="../.gitbook/assets/image (81).png" alt="Set priority from the incident page"><figcaption><p>Set priority and severity directly from the incident page.</p></figcaption></figure>
 
-### From Incident page
+### From integrations
 
-You will find these options on the incident page for both priority and severity.&#x20;
+Some integrations, like Azure, send priority and severity as part of their incident payload. Spike reads these values and sets them automatically, overwriting any existing values.
 
-![Setting priority from the incident page](<../.gitbook/assets/image (81).png>)
+You can also send priority and severity via [webhook integration](../integrations-guideline/integrating-with-webhooks.md).
 
-### From integrations (automated)
+### From alert rules and Playbooks
 
-Integrations like Azure send priority and severity with their incident details. We will acknowledge this and overwrite your incident's priority and severity.
+You can set priority and severity automatically using [alert rules](../alerts/alert-rules.md) based on incident properties. [Playbooks](../playbooks/introduction-to-playbooks.md) can also set them as part of an automated response when an incident fires.
 
-{% hint style="success" %}
-You can also send priority and severity with webhook integration. [Learn more](https://docs.spike.sh/integrations-guideline/integrating-with-webhooks)
-{% endhint %}
-
-## F.A.Q
+## FAQ
 
 ### Should I set both priority and severity?
 
-It's recommended to do so, at least for critical incidents. However, if you would like, you can choose to only use one.&#x20;
+For critical incidents, yes. For lower-signal integrations, you can use just one or neither. Both fields are optional.
 
-### Who has access to set and unset?
+### Who can set priority and severity?
 
-Everyone. There is no access control because we believe tackling incidents is a team effort.&#x20;
+Everyone on the team. There are no restrictions on who can set or change these fields.
+
+### Can I set priority and severity automatically?
+
+Yes. Use [alert rules](../alerts/alert-rules.md) to set them based on incident properties, or connect integrations like Azure that send these values automatically with each incident.

--- a/incidents/reassign-incidents.md
+++ b/incidents/reassign-incidents.md
@@ -1,33 +1,29 @@
 ---
-description: Reassign the incident to any of your team mates
+description: Reassign an incident to any team member directly from the dashboard, incident page, or service view.
 ---
 
 # Reassign incidents
 
-### How to reassign incidents?
+You can reassign any incident to a team member. Once reassigned, they receive an email notification.
 
-Select any number of incidents and click on **reassign** on the header of the incidents table. 
+## How to reassign
 
-![Reassign button on incidents table](../.gitbook/assets/reassign-button.png)
+Select one or more incidents and click **Reassign** in the incidents table header.
 
-You can reassign an incident to a team member. Not all incidents will have assignee to it, especially when you have Slack app notifying you on channels.
+<figure><img src="../.gitbook/assets/reassign-button.png" alt="Reassign button on the incidents table"><figcaption><p>The Reassign button appears in the incidents table header after selecting an incident.</p></figcaption></figure>
 
-![Reassigned incident](<../.gitbook/assets/image (39).png>)
+<figure><img src="../.gitbook/assets/image (39).png" alt="Reassigned incident"><figcaption><p>A reassigned incident shows the new assignee.</p></figcaption></figure>
 
-Once reassigned, the user will get an email notifying them about it. 
+The reassign option is available from:
 
-### What happens to escalations?
-
-Your escalation policy for the incident _will NOT be affected_. It will continue as is. 
-
-### Where do I reassign incident(s)?
-
-You will see the reassign incident option on every incident table. More particularly it can be found on -
-
-1. Dashboard
-2. Incident details page
-3. Incidents listed for a service
+- Dashboard
+- Incident details page
+- Incidents listed for a service
 
 {% hint style="danger" %}
-You cannot assign an incident to a team member with **Support role**
+You cannot reassign an incident to a team member with the **Support** role.
 {% endhint %}
+
+## Effect on escalations
+
+Reassigning an incident does not affect the escalation policy. The policy continues running as configured.

--- a/incidents/sharing-incidents.md
+++ b/incidents/sharing-incidents.md
@@ -1,29 +1,27 @@
 ---
-description: Share your incidents with the world, embed in your docs and more.
+description: Share any incident as a public link with customers, stakeholders, or your team.
 ---
 
 # Sharing incidents
 
-### Global settings to allow sharing
+You can share any incident as a public link. This is useful for communicating outages to customers or embedding status updates in your docs.
 
-To share incidents publicly,  you will first need to allow sharing of incidents for your entire organisation globally.&#x20;
+## Enable public sharing
 
-Head over to [Alerts under organisation settings](https://app.spike.sh/settings/general/alerts) and select your choice to enable or disable your team from sharing incidents publicly.
+Public sharing is off by default. To turn it on, go to [Alerts under organisation settings](https://app.spike.sh/settings/general/alerts) and enable it for your organisation.
 
-![Enable public sharing from organisation settings](<../.gitbook/assets/image (46).png>)
+<figure><img src="../.gitbook/assets/image (46).png" alt="Enable public sharing from organisation settings"><figcaption><p>Enable public sharing from organisation settings.</p></figcaption></figure>
 
 {% hint style="info" %}
-If public incidents are disabled in organisation settings then all public incident links will be private instantly.&#x20;
+If you disable public sharing in organisation settings, all existing public incident links become private immediately.
 {% endhint %}
 
-### Sharing a single incident
+## How to share an incident
 
-To share an incident, you will need to click on the **Share** button on the right-hand side of the incident details page.&#x20;
+Open an incident and click the **Share** button on the right-hand side of the incident details page.
 
-![Share as public page](<../.gitbook/assets/image (47).png>)
-
-The link for the public page will **not be unique** for each time to decide to share or not. However, the public page link is unique to each incident.
+<figure><img src="../.gitbook/assets/image (47).png" alt="Share an incident as a public link"><figcaption><p>Click Share on the incident details page to get a public link.</p></figcaption></figure>
 
 {% hint style="info" %}
-You will not see the share button if public incidents are disabled in organisation settings as mentioned in the above section
+Each incident has a unique public link. The link stays the same regardless of how many times you toggle sharing on or off.
 {% endhint %}

--- a/incidents/what-is-an-incident.md
+++ b/incidents/what-is-an-incident.md
@@ -1,44 +1,39 @@
 ---
-description: Learn the basics of an incident.
+description: An incident is any issue that needs to be investigated and resolved, often one that affects your customers.
 ---
 
 # What is an incident?
 
-Incident is any issue that needs to be worked upon and resolved. Many a times, these incidents often affects your customers. When we get an incident, we alert and assign the incident to the right person using escalation policy attached to that integration.
+An incident is any issue that needs to be investigated and resolved. When a connected monitoring tool detects a problem, Spike creates an incident and alerts the right person based on the [escalation policy](../escalations/introduction-to-escalations.md) attached to that integration.
 
 ## Examples
 
-1. Monitoring CPU utilization - alerts at high utilization at say, 80%
-2. Monitoring Memory consumption - alerts at high consumption at say, 90%
-3. DB monitoring alerts&#x20;
-4. DB backup fails
-5. Billing fails
-6. Sending notification fails
-7. Errors on loading dashboard
-8. Website down monitored with uptime monitoring
+Common examples of incidents include:
 
-_and many more ...._
+- CPU or memory utilization crossing a critical threshold
+- Database monitoring alerts
+- Database backup failures
+- Billing process failures
+- Notification delivery failures
+- Dashboard loading errors
+- Website downtime
 
 {% hint style="info" %}
-You can use a simple webhook integration and create incidents from your code too. [Know more here.](https://docs.spike.sh/integrations-guideline/integrating-with-webhooks)
+You can also create incidents directly from your code using a [webhook integration](../integrations-guideline/integrating-with-webhooks.md).
 {% endhint %}
 
-## Understanding incident statuses
+## Incident statuses
 
-Incidents can have one of the below statuses -&#x20;
-
-1. **Triggered**
-2. **Acknowledged**
-3. **Resolved**
+Every incident has one of three statuses. See [incident statuses](incident-statuses.md) for the full breakdown.
 
 ### Triggered
 
-When an incident is **triggered**, Spike loads the escalation policy attached to the integration and sends an alert. _We continue to send automated alerts based on the escalation policy until the incident is acknowledged_. Once the person has received the alert, they choose to acknowledge or resolve. We do not send alerts when incidents are acknowledged and resolved. In this state, repeat incidents are automatically suppressed and logged reducing alert fatigue.
+A triggered incident means Spike has detected a problem and is actively alerting. Spike works through the escalation policy, sending alerts until someone acknowledges or resolves the incident. Repeat incidents are automatically suppressed to reduce [alert fatigue](../alerts/personal-alerts-management/README.md).
 
 ### Acknowledged
 
-An **acknowledged** incident would mean that the work for the resolution of incident is ongoing. In this state, we **do not** send any alerts and stop the escalation policy to where it stands. You can customise the settings to have a timeout for amount of time the incident remains in acknowledged state and does not get resolved. Once this timeout reaches, we change the status to triggered and start sending alerts again. _The acknowledge timeout setting is optional._ In this state, repeat incidents are automatically suppressed and logged reducing alert fatigue
+An acknowledged incident means someone is working on a fix. Spike stops alerting and pauses the escalation policy. You can optionally set an [acknowledge timeout](acknowledge-timeout.md): a time limit after which Spike moves the incident back to triggered and resumes alerting if it hasn't been resolved.
 
 ### Resolved
 
-Once incident has been fixed, you can mark it as **resolved**. In this case, no alerts are sent and escalation policy resets in case if there is a new incident again.
+A resolved incident means the issue is fixed. Spike stops all alerts and resets the escalation policy for any future incidents on that integration.

--- a/incidents/why-does-message-parsing-fail.md
+++ b/incidents/why-does-message-parsing-fail.md
@@ -1,46 +1,27 @@
 ---
-description: >-
-  We parse the data integrations send in JSON to human readable format.
-  Sometimes it fails. What does it mean and why does it happen?
+description: Message parsing fails when Spike cannot convert an integration's JSON payload into a readable format.
 ---
 
 # Why does message parsing fail?
 
-## Message parsing failed
+When an integration triggers an incident, Spike parses the JSON payload into a readable format. Some integrations send payloads in formats the parser doesn't recognise, and that's when it fails.
 
-After you setup integrations on Spike.sh, these integrations send us payload of JSON data for every new incident. We convert this JSON data into a human-readable format which is then used on the [incidents table](https://app.spike.sh/incidents) and in phone calls, emails, Slack etc. 
+<figure><img src="../.gitbook/assets/image (40).png" alt="Example of incident message parsing fail"><figcaption><p>An incident with a failed message parse in the incidents table.</p></figcaption></figure>
 
-Sometimes, this parsing fails and your table might see an entry like below - 
+## Does it affect alerts?
 
-![Example of incident message parsing fail](<../.gitbook/assets/image (40).png>)
+Yes. Alerts still go out, but the incident message won't be included.
 
-### Report with a single click
+## Does it affect the incident?
 
-When you see this, please report this issue to us so we can start looking into this. The more you report the better this parsing gets.
+No. The incident is still created and all details are available. Click the incident ID to view the full details.
 
-![Report with a single click](../.gitbook/assets/spike-incident-parsing-fail-report.gif)
+## Report a parsing failure
 
-### Why does this happen?
+When you see a parsing failure, report it with a single click. Each report helps improve the parser for future incidents.
 
-We try our best to parse all the payloads and convert it into a gist you can actually read and get a sense of the incident. Each integration has tons of cases and our parser fails to understand it and that's what causes Incident message parsing fail. 
-
-### Does it affect my alerts?
-
-Yes, your alerts will not have the message. 
-
-### Would I still receive alerts?
-
-Yes. Alerts will still be sent however the exact incident message will not be available. 
-
-### Is the incident affected?
-
-No. The details of your incident are still available. You can click on the #ID of the incident and see all the details as you do with other incidents.
-
-### Should we take any action?
-
-We would love it if you can please report the incident. 
+<figure><img src="../.gitbook/assets/spike-incident-parsing-fail-report.gif" alt="Report a parsing failure with a single click"><figcaption><p>Report a parsing failure directly from the incidents table.</p></figcaption></figure>
 
 {% hint style="warning" %}
-Once the parser is fixed, it will not change the message for existing incidents but it will surely pave the way for future incidents
+Once the parser is fixed, existing incidents won't be updated. The fix applies to new incidents only.
 {% endhint %}
-

--- a/what-is-spike.md
+++ b/what-is-spike.md
@@ -1,65 +1,49 @@
 ---
-description: >-
-  Spike.sh is a simple incident management platform. We help you by alerting the right team members about incidents that affect your customer.
+description: Spike is an incident management platform that pages the right person when something breaks in your infrastructure.
 ---
+
 # What is Spike.sh?
 
-Spike.sh is a simple incident management platform. We help you by alerting the right team members about incidents that affect your customer.&#x20;
+Spike is an incident management platform. Connect your monitoring tools, define who gets paged and how, and Spike handles alerting when incidents fire.
 
-## Focusing on simplicity
+## How Spike works
 
-Spike.sh's mission is to reduce the complexity of managing incidents and make it simple so teams of all sizes use it.&#x20;
+Every incident starts with an integration. When a connected monitoring tool detects a problem, it sends a signal to Spike. Spike creates an incident and triggers your escalation policy, which determines who gets notified and through which channel. If no one responds in time, Spike moves to the next person in line. Once resolved, reports capture the data so your team can track patterns over time.
 
-**Our platform consists of a few modules -**
-
-1. Integrations
-2. Alerts
-3. Escalations
-4. Services
-5. On-call schedules
-6. Reports
-7. Automation
-    - Alert rules: automate routing alerts, setting priority and severity, triggering outbound webhooks
-    - Outbound webhooks: trigger your scripts by creating an outbound webhook (GET/POST/PUT requests)
-    - Title remapper: extract values from an incident and change the incident title programatically for better context
-    - Playbooks (beta): Automate common actions like creating war rooms or creating a ticket on JIRA, or updating your status page
-
-{% hint style="info" %}
-To get in depth, please reach out to us at [demo@spike.sh](mailto:demo@spike.sh) or book a call directly on our [calendar](https://calendly.com/spikehq).&#x20;
-{% endhint %}
+## Core modules
 
 ### Integrations
 
-{% content-ref url="integrations-guideline/setup-integrations.md" %}
-[setup-integrations.md](integrations-guideline/setup-integrations.md)
-{% endcontent-ref %}
-
-We integrate with a number of services and tools so you can use Spike as a central intelligence as we gather incidents and alert the right person. You can add an unlimited number of integrations, there are no restrictions. Each integration would have a separate identifiable token so you needn't worry about incidents mixing up and rest knowing that we have got you covered.
+Spike connects to [over 100 monitoring, logging, and observability tools](integrations-guideline/setup-integrations.md). Each integration gets a unique token, so incidents from different sources stay separate. You can add as many integrations as you need with no restrictions.
 
 {% hint style="info" %}
-We have a growing [list of integrations](https://spike.sh/integrations). If you don't see an integration you need then email us at [integrations@spike.sh](mailto:integrations@spike.sh) and we would be happy to build it for you and release it for everyone.
+Don't see an integration you need? Email [integrations@spike.sh](mailto:integrations@spike.sh) and we'll build it.
 {% endhint %}
 
 ### Services
 
-![Services on spike](<.gitbook/assets/affected services.png>)
+<figure><img src=".gitbook/assets/affected services.png" alt="Services on Spike"><figcaption><p>Services map to components in your infrastructure.</p></figcaption></figure>
 
-**You can think of services as a microservice.** Services are a way to scope your internal services from your architecture. Each of your service can have multiple integrations and you can create unlimited number of services. We highly encourage you to create different services for each of your different modules.
-
-You can create services by just adding a name to it. No other field is required. With the power of unlimited services, you can create a blueprint of your entire architecture on Spike. This way, we will tell which service is affected and what is the current health status in terms of open incidents.
+Services map to components in your infrastructure: a backend API, a payment service, a worker queue. Each service holds multiple integrations. When an incident fires, Spike shows which service is affected and its current health status based on open incidents. You can create as many services as you need to reflect your full architecture.
 
 ### Escalations
 
-![Multiple escalation policies](.gitbook/assets/escalations-list.png)
+<figure><img src=".gitbook/assets/escalations-list.png" alt="Escalation policies on Spike"><figcaption><p>Create separate escalation policies for teams, services, or situations.</p></figcaption></figure>
 
-We provide simplicity by un-complicating escalation policies by allowing you to choose your alert channels. Anyone from your team can create escalation policies you can easily use. With the power of unlimited escalations, you can create escalations policies just for your self or one for your team and one for every team in your organization.
+An [escalation policy](escalations/introduction-to-escalations.md) defines who gets paged and in what order. You can build separate policies for different teams or services. If the first person doesn't acknowledge in time, Spike moves down the policy until someone responds.
 
-### Reports
+### Alerts
 
-![](<.gitbook/assets/Screenshot 2020-06-24 at 10.38.57 AM.png>)
+Spike reaches your team through phone calls, SMS, email, Slack, Microsoft Teams, WhatsApp, Telegram, Discord, and Pushover. Each person sets their own alert preferences. [Alert rules](alerts/alert-rules.md) let you route, filter, and prioritize alerts automatically based on incident properties.
 
-![Reports and data you will actually use](<.gitbook/assets/image (18).png>)
+### On-call schedules
 
-No matter the size of your team, we believe everyone should have access to reports to bring in transparency to know how your platform measures in terms of open incidents. **We provide graphs to get a sense of total incidents, new incidents and repeated incidents for a given time period.**
+[On-call schedules](oncall-schedules/introduction-to-on-call-schedules.md) control who is on-call at any given time. Build schedules with layers and slots, set up overrides for coverage gaps, and sync shifts to Google Calendar, Apple Calendar, or Outlook.
 
-__
+### Playbooks
+
+[Playbooks](playbooks/introduction-to-playbooks.md) automate the repetitive work that happens when an incident fires. Create a war room, open a Jira ticket, update your status page. Playbooks run these steps automatically so your team can focus on the fix.
+
+{% hint style="info" %}
+To see Spike in action, book a call at [calendly.com/spikehq](https://calendly.com/spikehq) or email [demo@spike.sh](mailto:demo@spike.sh).
+{% endhint %}


### PR DESCRIPTION
## What changed
- Added a concise two-sentence opener explaining what parsing does and why it fails
- Removed redundant ## header that repeated the page title
- Removed all first-person voice ("we parse," "we try our best")
- Fixed both images to use `<figure>` tags
- Merged two redundant "report it" sections into one
- Tightened the warning hint block
- Fixed "Spike.sh" to "Spike"

## Why
The original page was written in first-person and had redundant sections. The page title and a section header asked the same question, and two sections both said "please report it."