### PR TITLE
docs: revamp how to create an escalation policy page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -31,7 +31,7 @@
 * [Telegram](alerts/telegram.md)
 * [Pushover](alerts/pushover.md)
 * [Discord](alerts/discord.md)
-* [Alert rules](alerts/alert-rules.md)
+* [Alert routing rules](alerts/alert-rules.md)
 * [Title Remapper](alerts/title-remapper.md)
 * [Personal alerts management](alerts/personal-alerts-management/README.md)
   * [During office hours](alerts/personal-alerts-management/during-office-hours.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,7 +17,7 @@
 * [Sharing incidents](incidents/sharing-incidents.md)
 * [Why does message parsing fail?](incidents/why-does-message-parsing-fail.md)
 * [Rate limiting on duplicate incidents](incidents/rate-limiting-on-duplicate-incidents.md)
-* [Resolved by Timer](incidents/resolve-timer.md)
+* [Resolve by Timer](incidents/resolve-timer.md)
 
 ## Alerts
 

--- a/alerts/alert-rules.md
+++ b/alerts/alert-rules.md
@@ -1,110 +1,123 @@
 ---
-description: >-
-  Alert rules allows you to define a set of actions to perform based on simple
-  conditions.
+description: Alert routing rules apply automated actions to incidents based on conditions you define.
 ---
 
-# Alert rules
+# Alert routing rules
 
-## What are Alert rules?
+Alert routing rules evaluate conditions on every incoming incident and execute actions when those conditions are met. You can chain multiple conditions with AND/OR logic and apply multiple rulesets to a single incident.
 
-Alert rules help you route alerts efficiently and correctly for every incident. Setup specific conditions to either ignore an incident or assign it to a different member / escalation policy. One that's right for the incident.
+<figure><img src="../.gitbook/assets/alert_config.svg" alt="Example alert routing rule in Spike"><figcaption><p>An example alert routing rule with conditions and actions.</p></figcaption></figure>
 
-Visit the Alerts section from the sidebar and create a new alert rule.&#x20;
+## Conditions
 
+Each condition evaluates to true or false. If any condition block evaluates to true, Spike executes the configured actions.
 
-![Example alert rule](../.gitbook/assets/alert\_config.svg)
+### Apply to all incidents
 
-## **Conditions**
+Evaluates to true for every incident. Use this when an action should run unconditionally.
 
-You can create a group of conditions with an AND/OR clause. If any single block of condition(s) evaluates to True then we will execute the actions. But first, let's take a look at all the conditions -
+### Incident title
 
-### 1. Incident title
+Evaluates to true if the incident title contains, does not contain, equals, or does not equal a specific text or phrase.
 
-Evaluates to True if an incident title **contain/does not contain/equals/does not equal** a specific text or phrase
+<figure><img src="../.gitbook/assets/alert-rules-conditions-1.png" alt="Incident title condition"><figcaption><p>Incident title condition.</p></figcaption></figure>
 
-![Incident title](../.gitbook/assets/alert-rules-conditions-1.png)
+### Incident details
 
+Evaluates to true if a specific key in the incident details contains, does not contain, equals, or does not equal a specific value. Enter a key or nested key to compare against.
 
+### Incident has repeated
 
-### 2. Incident details&#x20;
+Evaluates to true if the total number of incident occurrences crosses a threshold you set.
 
-Evaluates to True if a specific key in incident details **contain/does not contain/equals/does not equal** a specific text or phrase. You will need to enter a specific key or nested key to compare with the text/phrase.
+### Incident has repeated within
 
-### 3. Occurrence
+Evaluates to true if incident occurrences cross a threshold within a given timeframe.
 
-Evaluates to True if the total incident occurrences crossed a specific threshold.
+### Incident suppressed
 
-### 4. Occurrences within a timeframe
+Evaluates to true if the incident has been suppressed at least a minimum number of times.
 
-Evaluates to True if incident occurrences cross a specific threshold in a given timeframe
+### Incident suppressed within
 
-### 5. Priority
+Evaluates to true if the incident has been suppressed at least a minimum number of times within a given timeframe.
 
-Evaluates to True if incident has a given priority. [Learn more about priority](https://docs.spike.sh/incidents/priority-and-severity#priority)
+### Priority
 
-### 6. Severity
+Evaluates to true if the incident has a given priority. [Learn more about priority](https://docs.spike.sh/incidents/priority-and-severity#priority)
 
-Evaluates to True if incident has a given severity. [Learn more about severity](https://docs.spike.sh/incidents/priority-and-severity#severity)
+### Severity
 
+Evaluates to true if the incident has a given severity. [Learn more about severity](https://docs.spike.sh/incidents/priority-and-severity#severity)
 
-### 7. Time of day
+### Time of day
 
-Evaluates to True if incident is triggered between the timestamps you have selected in any timezone. 
+Evaluates to true if the incident triggers between timestamps you set, in any timezone.
 
-### 8. All incidents
+### Days of week
 
-Evaluates to True for all incidents.
-
----
+Evaluates to true if the incident triggers on specific days of the week.
 
 ## Actions
 
-You can set one or more actions to execute
+Set one or more actions to execute when conditions are met.
 
-### 1. Reassign incident
+### Reassign incident to
 
-to anyone from your team on Spike.sh. An email is sent to the assignee.
+Assigns the incident to a team member. An email notification is sent to the assignee.
 
-### 2. Change escalation policy
+### Load escalation policy
 
-Instead of having to load the default escalation policy, you can change it dynamically with this action. For High severity incidents, load an escalation policy with everyone in it and for low priority incidents redirect them to Slack or MS Teams.
+Replaces the default escalation policy with one you specify. Useful for routing high-severity incidents to a more comprehensive policy.
 
-### 3. Do not create an incident
+### Change integration
 
-Not all incidents are major. Some are just not worth ending up on the dashboard or any alert channel.
+Changes the incident's integration.
 
-### 4. Priority
+This helps you set up a single webhook URL across multiple integrations, use conditions like incident title, and change the integration automatically.
 
-Assign the incident a Priority. [Learn more about priority](https://docs.spike.sh/incidents/priority-and-severity#priority)
+### Ignore incident
 
-### 5. Severity
+Prevents the incident from being created. No alerts are sent and the incident doesn't appear on the dashboard.
 
-Assign the incident a Severity. [Learn more about severity](https://docs.spike.sh/incidents/priority-and-severity#severity)
+### Mark priority as
 
-### 6. Auto acknowledge incidents
+Sets the incident's priority. [Learn more about priority](https://docs.spike.sh/incidents/priority-and-severity#priority)
 
-Create the incident but in the acknowledged state rather than the triggered state. Be mindful because this won't send any alerts but responders will see this as open incident on their dashboard.&#x20;
+### Mark severity as
 
-### 7. Auto resolve incidents
+Sets the incident's severity. [Learn more about severity](https://docs.spike.sh/incidents/priority-and-severity#severity)
 
-Create the incident but in resolved state rather than the triggered state. Be mindful because this won't send any alerts and responders will _not_ see them as open incidents on their dashboard.
+### Trigger outbound webhook
+
+Sends a webhook to a URL you specify when the conditions are met.
+
+### Acknowledge incident
+
+Creates the incident in the acknowledged state. No alerts are sent, but the incident appears as open on the dashboard.
+
+### Resolve incident
+
+Creates the incident in the resolved state. No alerts are sent and the incident doesn't appear as open on the dashboard.
+
+### Resolve by Timer
+
+Automatically resolves the incident after a set duration. [Learn more about Resolve by Timer](resolve-timer.md)
+
+## Route to other team
+
+Enable the **Route to other team** toggle in the Actions section to send an incident from one team to another. Select the source team, destination team, and destination integration.
 
 ## Applying multiple rulesets
 
-For an incident, multiple alert rulesets can also be applied. Consider the below example -
+Multiple alert routing rulesets can apply to a single incident. For example:
 
-![Alert ruleset 1](<../.gitbook/assets/image (82).png>)
+<figure><img src="../.gitbook/assets/image (82).png" alt="Alert routing ruleset example 1"><figcaption><p>Ruleset 1: mark as P5 if title contains "syslog".</p></figcaption></figure>
 
-![Alert ruleset 2](<../.gitbook/assets/image (83).png>)
+<figure><img src="../.gitbook/assets/image (83).png" alt="Alert routing ruleset example 2"><figcaption><p>Ruleset 2: change escalation policy if title contains "syslog".</p></figcaption></figure>
 
-According the above two alert rulesets, If an incident title contains **syslog** in it then the incident will be marked as **P5 priority** and subsequently, the escalation policy will also change to **Slack dev** (ref: Alert ruleset 2)
+If an incident title contains "syslog", both rulesets apply: the incident is marked P5 and the escalation policy changes to Slack dev.
 
 {% hint style="info" %}
-No more than 5 alert configs will be applied to a single incident to avoid infinite looping
+No more than 5 alert routing rulesets apply to a single incident.
 {% endhint %}
-
-
-
-
-

--- a/alerts/discord.md
+++ b/alerts/discord.md
@@ -1,59 +1,56 @@
 ---
-description: >-
-  Our Discord integration enables you to receive notification on a Discord
-  channel
+description: Spike sends incident alerts to Discord channels. Set it up using a webhook.
 ---
 
 # Discord
 
-## Get Discord notifications from Spike.sh
+<figure><img src="../.gitbook/assets/image (78).png" alt="Incident alert on Discord from Spike"><figcaption><p>Incident alert on Discord.</p></figcaption></figure>
 
-Our Discord alert channel is incredibly simple yet informative. Once you add Discord alert channel, you will get a neat hello from us. On every new incident, you will get Incident details along with the link to navigate and take action.
+## How to set up
 
-![Discord alerts from Spike.sh](<../.gitbook/assets/image (78).png>)
+{% stepper %}
+{% step %}
+### Create a webhook in Discord
 
-## How to setup?
+Navigate to your channel's **Settings** > **Integrations** and select **Webhooks**.
 
-With Discord, you can get alerts on your Discord workspace using the channel webhooks, by setting up and adding Discord to your escalation policy.
+<figure><img src="../.gitbook/assets/discord-1.png" alt="Webhook settings in a Discord channel"><figcaption><p>Webhook settings in a Discord channel.</p></figcaption></figure>
+{% endstep %}
+{% step %}
+### Name and copy the webhook URL
 
-**Step 1**
-
-Navigate to any channel's **settings** > **integrations.** Select the webhook integration on the integrations page.
-
-![](../.gitbook/assets/discord-1.png)
-
-**Step 2**
-
-Name the integration Spike.sh and copy the webhook URL. Download the below badge to use it as the avatar.
+Name the webhook **Spike** and copy the URL. You can use the badge below as the avatar.
 
 {% file src="../.gitbook/assets/spike-badge-400.png" %}
-Spike.sh badge for Discord
+Spike badge for Discord
 {% endfile %}
 
-![](../.gitbook/assets/discord-2.png)
+<figure><img src="../.gitbook/assets/discord-2.png" alt="Naming the webhook and copying the URL"><figcaption><p>Name the webhook and copy the URL.</p></figcaption></figure>
+{% endstep %}
+{% step %}
+### Paste the URL in Spike
 
-**Step 3**
+Go to [Settings > Organisation > Alerts](https://app.spike.sh/settings/general/alerts), paste the webhook URL in the Discord setup, and save.
 
-On Spike dashboard, navigate to [**settings >** **organisation > alerts**](https://app.spike.sh/settings/general/alerts)**.** Paste the copied webhook URL in the Discord setup and save.
-
-![Save the copied webhook url](../.gitbook/assets/discord-3.png)
+<figure><img src="../.gitbook/assets/discord-3.png" alt="Saving the Discord webhook URL in Spike"><figcaption><p>Paste the webhook URL in Spike settings.</p></figcaption></figure>
 
 {% hint style="success" %}
-Once saved, we will send an example message to your new Discord alert channel
+Once saved, Spike sends a test message to your Discord channel.
 {% endhint %}
+{% endstep %}
+{% step %}
+### Add Discord to your escalation policy
 
-**Step 4**
+Select Discord as a step in your [escalation policy](https://app.spike.sh/escalations).
 
-You should be able to find Discord option enabled in your escalation policy like so -
+<figure><img src="../.gitbook/assets/image (79).png" alt="Discord as a step in an escalation policy"><figcaption><p>Discord as a step in an escalation policy.</p></figcaption></figure>
+{% endstep %}
+{% endstepper %}
 
-![Our new Discord alert channel is enabled in escalation policy](<../.gitbook/assets/image (79).png>)
+## Remove a Discord channel
 
-***
-
-### Deleting Discord alert channel
-
-You can always delete this channel on Spike.sh but you must ensure that it's not part of any escalation policy.
+You can remove a Discord channel from Spike, but make sure it's not part of any active escalation policy before doing so.
 
 {% hint style="info" %}
-Our Discord bot currently does not accept inputs for you to acknowledge or resolve an incident.
+Discord doesn't support acknowledging or resolving incidents from the channel. Use the Spike dashboard, phone, SMS, or other alert channels to take action.
 {% endhint %}

--- a/alerts/email.md
+++ b/alerts/email.md
@@ -1,24 +1,17 @@
 ---
-description: >-
-  Spike sends e-mail alerts for incidents. Here is how the e-mail alert looks
-  like. It consists of information such as Incident details, stack trace,
-  service affected, public link to incident
+description: Spike sends email alerts for incidents, including incident details, stack trace, and a public link.
 ---
 
-# E-mail
+# Email alerts
 
-## Get e-mail alerts for your incident from Spike
+In your escalation policy, select the **Email** option and choose the team member who should receive it.
 
-In your escalation policy, you can choose to receive e-mail alert by selecting the **e-mail** option and the member who should receive it.&#x20;
-
-![e-mail alert on Spike](<../.gitbook/assets/image (1) (1) (1).png>)
+<figure><img src="../.gitbook/assets/image (1) (1) (1).png" alt="Email alert from Spike"><figcaption><p>Email alert from Spike.</p></figcaption></figure>
 
 {% hint style="info" %}
-Emails are sent via one of our multiple emails - alerts@spike.sh, alerts@spiked.sh. To make sure you always get the emails in your inbox, please download our vCard and add us as a contact in your email provider.
+Spike sends emails from alerts@spike.sh and alerts@spiked.sh. To make sure alerts land in your inbox, add these addresses as contacts or download the vCard below.
 {% endhint %}
 
 {% content-ref url="../administration/our-notification-numbers.md" %}
 [our-notification-numbers.md](../administration/our-notification-numbers.md)
 {% endcontent-ref %}
-
-Find our vCard by clicking on the link above ☝️

--- a/alerts/microsoft-teams.md
+++ b/alerts/microsoft-teams.md
@@ -1,104 +1,100 @@
 ---
-description: Get alerts on your Microsoft Teams from Spike.sh
+description: The Spike app for Microsoft Teams sends incident alerts to your channels. Acknowledge, resolve, or escalate incidents directly from Teams.
 ---
 
 # Microsoft Teams
 
-Our Microsoft Teams app simplifies incident management by delivering alerts directly to your Teams channels and enabling you to take immediate actions. Below is a quick overview of the available features:
+The Spike app for Microsoft Teams delivers incident alerts to your channels and on-call notifications to your DMs.
 
-1. **Receive Incident Alerts**: Get real-time incident alerts directly in your Teams channels
-2. **Create Incidents from Teams**: Seamlessly create new incidents directly from within Microsoft Teams and keep your workflow uninterrupted.
-3. **Manage Incidents**: Easily acknowledge, resolve, or escalate incidents.
-4. **On-call Notifications**: Receive direct messages for the start and end of your on-call shifts, invitations to join a war-room, and notifications when you're mentioned in a comment on Spike.sh.
-5. **On-Call Shift Information**: Quickly check who is currently on-call and get details about your current and upcoming on-call shift timings.
+Key features:
 
-[Install our Teams app](https://teams.microsoft.com/l/app/aea2c271-cfd3-4360-86bb-4a16998b2bde?source=app-details-dialog) directly or search for "Spike.sh" in the Teams Apps section on the sidebar. If you need assistance with installation due to permission restrictions, please contact your Teams admin.
+- Real-time incident alerts in Teams channels
+- Acknowledge, resolve, or escalate incidents from Teams
+- Create incidents directly from Teams
+- On-call shift notifications via DMs
+- Check who is currently on-call
+
+[Install the Teams app](https://teams.microsoft.com/l/app/aea2c271-cfd3-4360-86bb-4a16998b2bde?source=app-details-dialog) directly or search for "Spike" in the Teams Apps section. Contact your Teams admin if you need help with installation due to permission restrictions.
 
 {% embed url="https://www.youtube.com/watch?v=aLuMQXcaJEk" %}
 
-### Getting Started with the Spike App on Microsoft Teams
+## Getting started
 
-After installing the app, you'll receive a message with instructions on how to connect your Spike account. For full functionality, we recommend using both the `connect` **and** `connect-org` commands.
+After installing the app, you'll receive a message with instructions on how to connect your Spike account. Run both the `connect` and `connect-org` commands for full functionality.
 
 {% hint style="info" %}
-- The `connect` command links your personal Spike account with Teams, enabling direct messages for on-call shift notifications and when you are mentioned in a comment.
+- The `connect` command links your personal Spike account with Teams, enabling direct messages for on-call shift notifications and comment mentions.
+- The `connect-org` command links your organisation's Spike account with Teams, enabling incident alerts in channels.
 
-- The `connect-org` command links your organization’s Spike account with Teams. This will enable your org to receive actionable incident alerts in channels.
-
-For the best experience, we suggest running both commands.
+Run both commands for the best experience.
 {% endhint %}
 
-### Available Commands
+## Available commands
 
 {% tabs %}
 {% tab title="Commands in Microsoft Teams" %}
-* **New incident**:
-  * `/create-new-incident` - Create a new incident from Teams
-* **Am I on-call?**:
-  * `/oncall-me` - Check if you are on-call and when your shift ends.
-* **Who is on-call?**:
-  * `/oncall-now` - See who is currently on-call.
-* **Disconnect**:
-  * `/disconnect` - Disconnects your Spike account from Teams. _Note: This will only disconnect your personal account. Incident alerts will continue to be available in channels._
+* **New incident** (`/create-new-incident`): Create a new incident from Teams.
+* **Am I on-call?** (`/oncall-me`): Check if you are on-call and when your shift ends.
+* **Who is on-call?** (`/oncall-now`): See who is currently on-call.
+* **Disconnect** (`/disconnect`): Disconnects your personal Spike account from Teams. Incident alerts in channels continue.
 {% endtab %}
 {% endtabs %}
 
-### Setting Up Incident Alerts with the Spike App
+## Setting up incident alerts
 
-Once your account is connected, you can easily add any of your Teams channels to an escalation policy. To do this, select "Teams" in the escalation policy, and your available channels will automatically appear on the right-hand side.
+Once connected, add any Teams channel to an escalation policy. Select **Teams** in the escalation policy and your available channels appear on the right.
 
-![How incident alerts look on Teams](../.gitbook/assets/microsoft-teams-app-incident-alerts.png)
+<figure><img src="../.gitbook/assets/microsoft-teams-app-incident-alerts.png" alt="Incident alerts on Microsoft Teams"><figcaption><p>Incident alerts in a Teams channel.</p></figcaption></figure>
 
-Any team member can take action on an incident directly from Teams. We recommend creating a dedicated channel for responders to receive and manage alerts. If an incident is acknowledged or resolved via the Spike dashboard, phone call, email, or any other medium, the latest incident will be automatically reflected in the Teams channel, along with the suppressed and repeated counts.
+Any team member can take action on an incident directly from Teams. Creating a dedicated channel for responders is a good practice.
 
-### Direct Messages (DMs)
+If an incident is acknowledged or resolved via the Spike dashboard, phone, email, or any other channel, the Teams message updates automatically with the latest status, including suppressed and repeat counts.
 
-![How incident alerts look on Teams](<../.gitbook/assets/all dms on teams from Spike.png>)
+## Direct messages
 
-After running the connect command, you can use the `oncall-me` and `oncall-now` commands to get information about your on-call schedules directly in Teams. You will also receive direct messages from Spike.sh for important notifications, such as:
+<figure><img src="../.gitbook/assets/all dms on teams from Spike.png" alt="Direct messages from Spike on Microsoft Teams"><figcaption><p>Direct messages from Spike in Teams.</p></figcaption></figure>
 
-1. Invites to War rooms
-2. Mentions in comments
-3. The ability to create new incidents directly from Teams
-4. Your on-call shift alerts
+After running the `connect` command, Spike sends direct messages for:
 
-## Connecting multiple groups on Teams
-The Spike bot allows you to connect to multiple groups of channels in Microsoft Teams. This makes it easy for organizations with several teams to receive alerts and manage incidents directly from Teams.
+1. War room invites
+2. Comment mentions
+3. On-call shift alerts
 
-### How to connect?
-1. In Microsoft Teams, go to the channel of the desired group you want to connect.
+Use `/oncall-me` and `/oncall-now` to check on-call schedules directly in Teams.
+
+## Connecting multiple groups
+
+The Spike bot connects to multiple groups of channels in Teams. This is useful for organisations with several teams.
+
+### How to connect
+
+1. In Teams, go to the channel of the group you want to connect.
 2. Type `@Spike.sh connect-org` to connect with Spike.
 
-There is no limit on how many groups can be connected. 
+There is no limit on how many groups can be connected.
 
-### After connecting:
-- Visit your [Escalation Policies](https://app.spike.sh/escalations) on Spike and add your desired channel to receive alerts.
-- You’ll see the newly connected Teams channels listed in the dropdown menu.
+### After connecting
 
-### NOTE on Finding channels in Escalations
-Microsoft Teams shows the group (Team) name only alongside the first channel name from each group. However, the first channel name appears as "standard" instead of the actual channel name.
+- Visit your [Escalation Policies](https://app.spike.sh/escalations) and add the desired channel to receive alerts.
+- The newly connected Teams channels appear in the dropdown.
 
-Other channels from the same group do not display the group name. This can cause confusion if you have similarly named channels across different groups.
+### Finding channels in escalations
+
+Teams shows the group name only alongside the first channel from each group. The first channel appears as "standard" instead of the actual channel name. Other channels from the same group don't show the group name. This can cause confusion if you have similarly named channels across different groups.
+
+<figure><img src="../.gitbook/assets/microsoft-teams/naming-convention-issue.png" alt="Naming convention for Microsoft Teams channels in escalations"><figcaption><p>How Teams channel names appear in escalation policies.</p></figcaption></figure>
 
 For example:
 
+- **Spike.sh - standard**: the first channel in the "Spike.sh" group, even if the channel's actual name is different
+- **Engineering**: another channel in the same group, shown without the group name
+- **Developer space - standard**: the first channel in "Developer space"; actual name is "dev space"
+- **Incidents**: another channel in the same group, shown without the group name
 
-![Naming convention in escalations for Microsoft teams channels](../.gitbook/assets/microsoft-teams/naming-convention-issue.png)
-
-
-- **Spike.sh - standard** (this refers to the first channel in the “Spike.sh” group, even if the channel’s actual name is different)
-- **Engineering** (another channel in the same group, shown without the group name)
-- **Developer space - standard** (the first channel in “Developer space”; actual name is “dev space,” but shown as “standard”)
-- **Incidents** (another channel in the same group, shown without the group name)
-***
-
-## Deprecated - Get Teams alerts from Spike using Incoming Webhook
+## Deprecated: incoming webhook
 
 {% hint style="warning" %}
-Microsoft has deprecated all new webhook connectors on 15th September and Spike has officially deprecated the incoming webhook support on 26th November 2024.
+Microsoft deprecated all new webhook connectors on 15th September 2024. Spike deprecated incoming webhook support on 26th November 2024.
 {% endhint %}
 
-The alert messages on Microsoft Teams (referred to as Teams from here on) comes with gists for you and your team to quickly learn about the incident.
-
-![How incident alerts look on Teams](<../.gitbook/assets/image (59).png>)
-
+<figure><img src="../.gitbook/assets/image (59).png" alt="Incident alert via incoming webhook on Teams"><figcaption><p>Incident alert via the deprecated incoming webhook method.</p></figcaption></figure>

--- a/alerts/mobile-app-alerts.md
+++ b/alerts/mobile-app-alerts.md
@@ -1,39 +1,46 @@
 ---
-description: Spike's mobile app quickly gets you upto speed on ongoing incidents.
+description: Spike's mobile app delivers real-time incident alerts to your phone, with support for critical notifications on iOS and Android.
 ---
 
 # Mobile app alerts
 
-<figure><img src="../.gitbook/assets/mobile-alerts.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/mobile-alerts.png" alt="Spike mobile app showing incident alerts"><figcaption><p>Spike mobile app alerts.</p></figcaption></figure>
 
-Spike's mobile app offers a super convenient way to stay ahead of incidents, so you’re always informed. With real-time notifications, you can quickly respond to critical issues, keeping your operations running smoothly. After downloading the app, make sure to log in and allow notifications to take full advantage of the alerting features.
+Spike's mobile app sends real-time incident alerts to your phone. Download the app, log in, and allow notifications to start receiving alerts.
 
 {% tabs %}
 {% tab title="iOS" %}
-<figure><img src="../.gitbook/assets/AppStore.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/AppStore.png" alt="Download on the App Store"><figcaption></figcaption></figure>
 
-[Download the iOS app](https://apps.apple.com/au/app/spike-sh/id1586777789) from the AppStore
+[Download the iOS app](https://apps.apple.com/au/app/spike-sh/id1586777789) from the App Store.
 {% endtab %}
-
 {% tab title="Android" %}
-<figure><img src="../.gitbook/assets/PlayStore.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/PlayStore.png" alt="Get it on Google Play"><figcaption></figcaption></figure>
 
-[Download the Android app](https://play.google.com/store/apps/details?id=sh.spike.spike\_sh\_app) from the PlayStore
+[Download the Android app](https://play.google.com/store/apps/details?id=sh.spike.spike\_sh\_app) from the Play Store.
 {% endtab %}
 {% endtabs %}
 
 ## Setup
 
-To receive notifications on your mobile device, make sure to set up phone notifications within your escalation policies. This will trigger mobile app alerts delivered directly to your phone, enabling you to respond promptly to incidents.
+To receive mobile alerts, add phone notifications to your escalation policies. Spike will then deliver alerts directly to your device.
 
 ## Critical alerts
 
-**For iOS users**, Spike's mobile app offers the option to receive Critical notifications (partnered with Apple) for critical incidents or for all incidents. This ensures that you never miss an important notification, even if your device is on Do Not Disturb mode. Visit settings on your app to configure further.
+Critical alerts reach you even when your device is on Do Not Disturb.
+
+### iOS
+
+Spike supports Apple's critical notifications. Configure this in the app settings to apply to critical incidents only, or all incidents.
 
 {% hint style="info" %}
-Critical notifications make sound even when your iPhone is muted
+Critical notifications make sound even when your iPhone is on mute.
 {% endhint %}
 
-**For Android users**, Spike offers high-priority notification channels that can alert you even when your device is on Do Not Disturb (DnD) mode. You'll be prompted to grant permission when you first receive critical notifications. You can also manage this anytime in your device's notification settings.
+### Android
 
-{% hint style="info" %} Spike creates a critical alerts channel on Android. When you sign in, you'll be prompted to allow these alerts to bypass Do Not Disturb. {% endhint %}
+Spike supports Android's critical notifications. Configure this in the app settings to apply to critical incidents only, or all incidents.
+
+{% hint style="info" %}
+Critical notifications make sound even when your Android device is on mute.
+{% endhint %}

--- a/alerts/personal-alerts-management/README.md
+++ b/alerts/personal-alerts-management/README.md
@@ -1,23 +1,19 @@
 ---
-description: >-
-  Manage your personal alert preferences to customize how, when, and where you
-  receive incident notifications, all designed a better work-life balance.
+description: Manage how, when, and where you receive incident alerts to suit your schedule and reduce alert fatigue.
 ---
 
 # Personal alerts management
 
-Spike provides a range of options to customize how you receive incident alerts. These settings allow you to tailor your alert preferences for office hours, out-of-office hours, and when incidents are triggered/resolved, so you have better control over your work-life balance.
+Spike gives you full control over your personal alert preferences. Configure how alerts reach you during office hours, outside office hours, and when you're away.
 
-With these settings, Spike helps you manage alerts in a way that suits your schedule. When you're out of office, Spike will stop sending alerts, allowing you to step away confidently. Be sure to reassign responsibilities to another team member when you're off duty.
+For example, when you're out of office, you can configure Spike to stop sending alerts. You can also reassign responsibilities to another team member when you're off duty.
 
-### Example Alert Configurations:
+## Example configurations
 
-* **During office hours**: Route all phone call alerts to app notifications.
-* **Outside office hours**: Prefer receiving alerts via SMS, WhatsApp, or Telegram.
-* **Out of office**: Forward all alerts to another team member.
+- **During office hours**: Route all phone call alerts to app notifications.
+- **Outside office hours**: Prefer receiving alerts via SMS, WhatsApp, or Telegram.
+- **Out of office**: Forward all alerts to another team member.
 
-These configurations are especially useful if you've spent extended periods responding to incidents or being on-call, giving you more flexibility and reducing alert fatigue.
-
-### Explore
+## Explore
 
 <table data-card-size="large" data-view="cards" data-full-width="false"><thead><tr><th></th><th></th><th data-hidden data-card-target data-type="content-ref"></th><th data-hidden data-card-cover data-type="files"></th></tr></thead><tbody><tr><td><strong>Resolved incident alerts</strong></td><td>Alerts when incidents are resolved</td><td><a href="resolved-incident-alerts.md">resolved-incident-alerts.md</a></td><td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-resolved-alerts.png">thumbnail-resolved-alerts.png</a></td></tr><tr><td><strong>During office hours</strong></td><td>Custom routing of alerts during office hours</td><td><a href="during-office-hours.md">during-office-hours.md</a></td><td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-office-hours.png</a></td></tr><tr><td><strong>Out of office</strong></td><td>Step away confidently by scheduling Out of office</td><td><a href="out-of-office.md">out-of-office.md</a></td><td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-out-of-office.png</a></td></tr><tr><td><strong>Deep work and Cooldown modes</strong></td><td>Catch a break with our 2 modes</td><td><a href="deep-work-and-cooldown-modes.md">deep-work-and-cooldown-modes.md</a></td><td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-deepwork.png">thumbnail-deepwork.png</a></td></tr></tbody></table>

--- a/alerts/personal-alerts-management/deep-work-and-cooldown-modes.md
+++ b/alerts/personal-alerts-management/deep-work-and-cooldown-modes.md
@@ -1,47 +1,41 @@
 ---
-description: "Spike offers two modes, Cooldown and Deep Work, to give responders much-needed breaks and focused work time without unnecessary alerts. These modes help balance alert fatigue while ensuring that critical incidents still get the attention they need."
+description: Deep work and Cooldown modes pause non-critical alerts for a set duration, giving you time to focus or recover without constant interruptions.
 ---
 
-<figure><img src="../../.gitbook/assets/personal-alerts-management/deepwork and cooldown mode.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/personal-alerts-management/deepwork and cooldown mode.png" alt="Deep work and Cooldown modes in Spike"><figcaption><p>Deep work and Cooldown modes.</p></figcaption></figure>
 
-# Cooldown & Deep work mode
-Both modes were designed with responder well-being in mind, offering much-needed breaks and uninterrupted work time. By allowing responders to rest or focus without being constantly alerted, these modes support better mental clarity and reduce alert fatigue.
+# Deep work & Cooldown modes
 
-While these modes currently operate independently, we may consider grouping them into a unified "Do Not Disturb" mode in the future. The goal is to give responders the flexibility to control when and how they receive alerts without sacrificing incident response quality.
+Deep work and Cooldown modes temporarily pause non-critical alerts for a set duration. SEV1 incidents come through in both modes.
 
+## Deep work mode
 
+Deep work mode suppresses all non-critical alerts. You can set the duration for 1, 2, or 4 hours. Custom durations are not supported.
 
-## Deep Work Mode
-
-Deep Work Mode is intended for responders who need uninterrupted time for focused work. When enabled, this mode temporarily suppresses all non-critical incident alerts (except SEV1) for either 4 or 8 hours. These options are preset and cannot be edited. During this time, you can focus on your work without the distraction of lower-severity alerts.
-
-You will receive critical incident (SEV1) alerts.
+You will receive SEV1 alerts.
 
 {% tabs %}
-{% tab title="Setup on desktop" %}
-* Access the dropdown from the header that says `Select a mode` 
-* Enable **Deep Work Mode** for either 4 or 8 hours with a single click.
+{% tab title="Desktop" %}
+* From the header, click **Select a mode**
+* Select **Deep work mode** and choose a duration
 {% endtab %}
 {% endtabs %}
 
----
+## Cooldown mode
 
-## Cooldown Mode
+Cooldown mode pauses all alerts. You can activate it for 12 or 24 hours. Use it after an overnight shift or an extended on-call period.
 
-Cooldown Mode is designed for responders who need a break after handling incidents, such as an overnight shift. This mode pauses all alerts for either 12 or 24 hours, depending on the option selected. During this period, responders will not receive any incident alerts, allowing them to rest and recharge.
-
-You will receive critical incident (SEV1) alerts.
+You will receive SEV1 alerts.
 
 {% tabs %}
-{% tab title="Setup on desktop" %}
-* Access the dropdown from the header that says `Select a mode` 
-* Select **Cooldown Mode** for either 12 or 24 hours with a single click.
+{% tab title="Desktop" %}
+* From the header, click **Select a mode**
+* Select **Cooldown mode** for either 12 or 24 hours
 {% endtab %}
 {% endtabs %}
 
----
+## Explore
 
-### Explore
 <table data-view="cards">
   <thead>
     <tr>
@@ -52,24 +46,23 @@ You will receive critical incident (SEV1) alerts.
     </tr>
   </thead>
   <tbody>
-  <tr>
+    <tr>
       <td><strong>Resolved incident alerts</strong></td>
       <td>Alerts when incidents are resolved</td>
-      <td><a href="resolved-incident-alerts.md">Broken link</a></td>
+      <td><a href="resolved-incident-alerts.md">resolved-incident-alerts.md</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-resolved-alerts.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
     <tr>
       <td><strong>During office hours</strong></td>
       <td>Custom routing of alerts during office hours</td>
-      <td><a href="during-office-hours.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-resolved-alerts.png</a></td>
+      <td><a href="during-office-hours.md">during-office-hours.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-office-hours.png</a></td>
     </tr>
     <tr>
       <td><strong>Out of office</strong></td>
       <td>Step away confidently by scheduling Out of office</td>
-      <td><a href="out-of-office.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-resolved-alerts.png</a></td>
+      <td><a href="out-of-office.md">out-of-office.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-out-of-office.png</a></td>
     </tr>
   </tbody>
 </table>
-

--- a/alerts/personal-alerts-management/during-office-hours.md
+++ b/alerts/personal-alerts-management/during-office-hours.md
@@ -1,53 +1,56 @@
 ---
-description: "Customize how alerts are routed during office hours to fit your work preferences."
+description: Customize how you receive alerts during office hours, for both incident triggers and resolutions.
 ---
 
-<figure><img src="../../.gitbook/assets/personal-alerts-management/Alerts during office hours - example.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../.gitbook/assets/personal-alerts-management/Alerts during office hours - example.png" alt="Alerts during office hours settings in Spike"><figcaption><p>Alert preferences during office hours.</p></figcaption></figure>
 
 # Alerts during office hours
-Customize how you receive alerts during office hours, whether for incident triggers or resolutions. If you’re working at your desk, you might prefer to route all SMS alerts to the [mobile app](../mobile-app-alerts.md) for better accessibility. Field engineers may prefer to continue receiving alerts via [SMS](../sms.md).
+
+Customize how alerts reach you during office hours. If you're at your desk, you might prefer app notifications over SMS. Field engineers may prefer to keep receiving alerts via [SMS](../sms.md) or [phone](../phone.md).
 
 {% hint style="info" %}
-On-call shift start/end alerts remain unaffected. If an incident occurs during your on-call shift within office hours, alerts will be sent according to your configured settings.
+On-call shift start/end alerts remain unaffected.
 {% endhint %}
 
-### Set up
+## Set up alert preferences
+
 {% tabs %}
 {% tab title="Mobile app" %}
-* Go to `Settings`
-* Tap on `Alerts during office hours`
-* Configure your alert preferences and tap `Save`
+* Go to **Settings**
+* Tap **Alerts during office hours**
+* Configure your alert preferences and tap **Save**
 {% endtab %}
 {% tab title="Desktop" %}
-  * Navigate to `Your account settings`([Dashboard link](https://app.spike.sh/settings/personal-modes#office-mode-alerts))
-  * Click `Modes`
-  * Configure your alert preferences and click `Save`
+* Navigate to [Your account settings](https://app.spike.sh/settings/personal-modes#office-mode-alerts)
+* Click **Modes**
+* Configure your alert preferences and click **Save**
 {% endtab %}
 {% endtabs %}
 
-## Setting office hours
-By default, your office hours are set to Monday through Friday, 9 AM to 5 PM in your local timezone ([found on profile page](https://app.spike.sh/settings/personal-profile)). You can customize these hours to fit your schedule, including different days and times.
+## Set office hours
 
-### Set up
+By default, your office hours are set to Monday through Friday, 9 AM to 5 PM in your local timezone ([found on your profile page](https://app.spike.sh/settings/personal-profile)). You can customize these hours to fit your schedule, including different days and times.
+
 {% tabs %}
 {% tab title="Mobile app" %}
-* Go to `Settings`
-* Tap on `Office hours`
-* Select your preferred days and times
-
+* Go to **Settings**
+* Tap **Office hours**
+* Select your preferred days and times and tap **Save**
 {% endtab %}
 {% tab title="Desktop" %}
-  * Navigate to `Your account settings` ([Dashboard link](https://app.spike.sh/settings/personal-modes))
-  * Click `Modes`
-  * Select your times and click `Save`
+* Navigate to [Your account settings](https://app.spike.sh/settings/personal-modes)
+* Click **Modes**
+* Select your times and click **Save**
 {% endtab %}
 {% endtabs %}
 
-**Download Spike mobile app**
+## Download the Spike mobile app
+
 - [iOS](https://apps.apple.com/au/app/spike-sh/id1586777789)
 - [Android](https://play.google.com/store/apps/details?id=sh.spike.spike_sh_app)
 
-### Explore
+## Explore
+
 <table data-view="cards">
   <thead>
     <tr>
@@ -58,23 +61,23 @@ By default, your office hours are set to Monday through Friday, 9 AM to 5 PM in 
     </tr>
   </thead>
   <tbody>
-  <tr>
+    <tr>
       <td><strong>Resolved incident alerts</strong></td>
       <td>Alerts when incidents are resolved</td>
-      <td><a href="resolved-incident-alerts.md">Broken link</a></td>
+      <td><a href="resolved-incident-alerts.md">resolved-incident-alerts.md</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-resolved-alerts.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
     <tr>
-      <td><strong>Out of office</td>
-      <td>Step away confidently by scheduling Out of office</strong></td>
-      <td><a href="out-of-office.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-resolved-alerts.png</a></td>
+      <td><strong>Out of office</strong></td>
+      <td>Step away confidently by scheduling Out of office</td>
+      <td><a href="out-of-office.md">out-of-office.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-out-of-office.png</a></td>
     </tr>
     <tr>
       <td><strong>Deep work and Cooldown modes</strong></td>
       <td>Catch a break with our 2 modes</td>
-      <td><a href="deep-work-and-cooldown-modes.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-deepwork.png">thumbnail-deepwork</a></td>
+      <td><a href="deep-work-and-cooldown-modes.md">deep-work-and-cooldown-modes.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-deepwork.png">thumbnail-deepwork.png</a></td>
     </tr>
   </tbody>
 </table>

--- a/alerts/personal-alerts-management/out-of-office.md
+++ b/alerts/personal-alerts-management/out-of-office.md
@@ -1,40 +1,43 @@
 ---
-description: "Set up Out of Office mode to temporarily pause alerts, schedule time off, and seamlessly offload duties to team members."
+description: Set up Out of Office mode to pause alerts and offload on-call duties to a team member while you're away.
 ---
-<figure><img src="../../.gitbook/assets/personal-alerts-management/out of office - example.png" alt=""><figcaption></figcaption></figure>
+
+<figure><img src="../../.gitbook/assets/personal-alerts-management/out of office - example.png" alt="Out of Office mode settings in Spike"><figcaption><p>Out of Office mode settings.</p></figcaption></figure>
 
 # Out of office
-Heading out of the office? You can schedule or instantly set up **Out of Office**, so your duties including on-call responsibilities and incident alerts are covered by a colleague.
 
-Out of Office mode is designed to support better work-life balance. **While you're away, Spike will not send you any alerts**. You can even schedule this ahead of time, and an email will be sent to the admins in your organization, keeping everyone informed.
+Out of Office mode pauses all alerts (incident alerts and resolve alerts) and transfers your on-call responsibilities to a team member while you're away. You can schedule it in advance or activate it instantly. Spike notifies your organization's admins by email when you set it up.
 
-## Offloading Duties
-When setting up Out of Office, you can offload your responsibilities to a selected team member. Spike takes care of everything automatically—there’s no need to manually move members in the on-call schedule or add overrides. Your on-call shifts and incident alerts will be temporarily rerouted to the designated member.
+## Offloading duties
+
+When setting up Out of Office, you can offload your responsibilities to a selected team member. Spike handles this automatically. No need to manually move members in the on-call schedule or add overrides. Your on-call shifts and incident alerts are temporarily rerouted to the designated member.
 
 {% hint style="info" %}
-Although optional, we recommend offloading your duties to make sure incidents are addressed in your absence and you are not disturbed.
+Offloading duties is optional but recommended. It keeps incidents covered while you're away and ensures you're not disturbed.
 {% endhint %}
 
-### Set up
+## Set up
+
 {% tabs %}
 {% tab title="From settings on Desktop" %}
-* Navigate to `Your account settings` ([Dashboard link](https://app.spike.sh/settings/personal-modes#vacation-mode))
-* Click `Modes`
-* Scroll down to **Out of office** 
-* Add **Starts on** and **Ends on**, then click `save`
+* Navigate to [Your account settings](https://app.spike.sh/settings/personal-modes#vacation-mode)
+* Click **Modes**
+* Scroll down to **Out of office**
+* Add **Starts on** and **Ends on**, then click **Save**
 
-*Optionally, select a member to offload duties*
+Optionally, select a member to offload duties.
 {% endtab %}
 {% tab title="From the header on Desktop" %}
-* From the header, click `Select a mode` 
+* From the header, click **Select a mode**
 * Select **Out of office** from the dropdown
-* Add **Starts on** and **Ends on**, then click `save`
+* Add **Starts on** and **Ends on**, then click **Save**
 
-*Optionally, select a member to offload duties*
+Optionally, select a member to offload duties.
 {% endtab %}
 {% endtabs %}
 
-### Explore
+## Explore
+
 <table data-view="cards">
   <thead>
     <tr>
@@ -45,23 +48,23 @@ Although optional, we recommend offloading your duties to make sure incidents ar
     </tr>
   </thead>
   <tbody>
-  <tr>
+    <tr>
       <td><strong>Resolved incident alerts</strong></td>
       <td>Alerts when incidents are resolved</td>
-      <td><a href="resolved-incident-alerts.md">Broken link</a></td>
+      <td><a href="resolved-incident-alerts.md">resolved-incident-alerts.md</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-resolved-alerts.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
     <tr>
       <td><strong>During office hours</strong></td>
       <td>Custom routing of alerts during office hours</td>
-      <td><a href="during-office-hours.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-resolved-alerts.png</a></td>
+      <td><a href="during-office-hours.md">during-office-hours.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-office-hours.png</a></td>
     </tr>
     <tr>
       <td><strong>Deep work and Cooldown modes</strong></td>
       <td>Catch a break with our 2 modes</td>
-      <td><a href="deep-work-and-cooldown-modes.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-deepwork.png">thumbnail-deepwork</a></td>
+      <td><a href="deep-work-and-cooldown-modes.md">deep-work-and-cooldown-modes.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-deepwork.png">thumbnail-deepwork.png</a></td>
     </tr>
   </tbody>
 </table>

--- a/alerts/personal-alerts-management/resolved-incident-alerts.md
+++ b/alerts/personal-alerts-management/resolved-incident-alerts.md
@@ -1,67 +1,54 @@
 ---
-description: "Customize how and when you receive notifications for resolved incidents, keeping you informed without unnecessary alerts."
+description: Customize how and when you receive alerts for resolved incidents.
 ---
-<figure><img src="../../.gitbook/assets/personal-alerts-management/resolved incidents - configuration.png" alt=""><figcaption></figcaption></figure>
+
+<figure><img src="../../.gitbook/assets/personal-alerts-management/resolved incidents - configuration.png" alt="Resolved incident alerts configuration in Spike"><figcaption><p>Resolved incident alerts configuration.</p></figcaption></figure>
 
 # Resolved incident alerts
-Spike notifies you when incidents are automatically resolved or resolved by a responder. This helps provide closure and peace of mind, ensuring you’re informed that an incident you were alerted to has been resolved. It completes the alert cycle effectively.
 
-By default, only current responders and members who were alerted when the incident was triggered will receive a resolved incident alert.
+Spike notifies you when an incident you were alerted to has been resolved. By default, only current responders and members who were alerted when incident was triggered receive resolved alerts. You can customize the channels and configure different [preferences for office hours](during-office-hours.md).
 
-You can customize how you receive resolved incident alerts, including different mediums during office hours.
-
-{% hint style="info" %} 
-The Spike mobile app is ideal for instant notifications when incidents are resolved. 
+{% hint style="info" %}
+The Spike mobile app is ideal for instant notifications when incidents are resolved.
 {% endhint %}
 
-### Set up
+## Set up
+
 {% tabs %}
 {% tab title="Mobile app" %}
-* Go to `Settings`
-* Tap on `Resolved alerts`
+* Go to **Settings**
+* Tap **Resolved alerts**
 * Configure your alerts
 
-**Download Spike mobile app**
+**Download the Spike mobile app**
 - [iOS](https://apps.apple.com/au/app/spike-sh/id1586777789)
 - [Android](https://play.google.com/store/apps/details?id=sh.spike.spike_sh_app)
-
 {% endtab %}
 {% tab title="Desktop" %}
-  * Navigate to `Your account settings` ([Dashboard link](https://app.spike.sh/settings/personal-modes#resolved-alerts))
-  * Scroll down to `Resolved alerts`
-  * Congiure your alerts and click `Save`
+* Navigate to [Your account settings](https://app.spike.sh/settings/personal-modes#resolved-alerts)
+* Scroll down to **Resolved alerts**
+* Configure your alerts and click **Save**
 {% endtab %}
 {% endtabs %}
 
 ## FAQs
-<details> 
 
-<summary>Can I get notifications for all incidents?</summary>
-No, by design, Spike only alerts current responders and members who were previously notified of the incident. This prevents alert fatigue and ensures that those who were not involved are not disturbed unnecessarily.
+### Do all team members receive resolved incident alerts?
 
-</details>
+No. Spike only sends resolved alerts to current responders and members who were notified when the incident triggered. This prevents alert fatigue and avoids notifying people who weren't involved.
 
-<details>
+### Will I receive another alert on Slack, Microsoft Teams, or Discord?
 
-<details> <summary>Will I receive another alert on Slack, Microsoft Teams, or Discord?</summary>
+**Slack and Microsoft Teams:** No new alert is sent. The original message in your channel updates automatically to show the resolved status.
 
-**Slack and Microsoft Teams:** There will be no new alert, but the original alert message in your Slack or Teams channels will automatically refresh to indicate the resolved status.
+**Discord:** No additional alert is sent.
 
-**Discord:** No additional alert will be sent.
+### Why can't I receive a phone call for a resolved incident alert?
 
-</details>
+Resolved alerts don't warrant a phone call. Keeping phone calls reserved for newly triggered incidents avoids confusion. When Spike calls you, it will always be for a new incident.
 
-<details>
+## Explore
 
-<summary>Why can't I receive a phone call for a resolved incident alert?</summary>
-
-Resolved incident alerts are important, but not critical enough to wake you in the middle of the night with a phone call. This avoids confusion—when you receive a phone call from Spike, it will always be for a newly triggered incident, so there’s no need to guess whether it’s for a new or resolved alert.
-
-</details>
-
----
-
-### Explore
 <table data-view="cards">
   <thead>
     <tr>
@@ -75,20 +62,20 @@ Resolved incident alerts are important, but not critical enough to wake you in t
     <tr>
       <td><strong>During office hours</strong></td>
       <td>Custom routing of alerts during office hours</td>
-      <td><a href="during-office-hours.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-resolved-alerts.png</a></td>
+      <td><a href="during-office-hours.md">during-office-hours.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-office-hours.png</a></td>
     </tr>
     <tr>
       <td><strong>Out of office</strong></td>
       <td>Step away confidently by scheduling Out of office</td>
-      <td><a href="out-of-office.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-resolved-alerts.png</a></td>
+      <td><a href="out-of-office.md">out-of-office.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-out-of-office.png</a></td>
     </tr>
     <tr>
       <td><strong>Deep work and Cooldown modes</strong></td>
       <td>Catch a break with our 2 modes</td>
-      <td><a href="deep-work-and-cooldown-modes.md">Broken link</a></td>
-      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-deepwork.png">thumbnail-deepwork</a></td>
+      <td><a href="deep-work-and-cooldown-modes.md">deep-work-and-cooldown-modes.md</a></td>
+      <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-deepwork.png">thumbnail-deepwork.png</a></td>
     </tr>
   </tbody>
 </table>

--- a/alerts/phone.md
+++ b/alerts/phone.md
@@ -1,27 +1,19 @@
 ---
-description: >-
-  Spike calls you on your phone to report an incident. On the phone call, you
-  can choose to acknowledge, resolve or escalate
+description: Spike calls your phone when an incident triggers. During the call, you can acknowledge, resolve, or escalate.
 ---
 
-# Phone
+# Phone alerts
 
-## Get phone alerts from Spike
+When an incident triggers, Spike calls your phone. During the call, press a key to take action:
 
-We always recommend using the phone alerts from Spike. This lets you know immediately when a serious issue might be affecting your customer. No matter the size of your business, incidents affect each customer the same. \
-\
-Never miss out with selecting the Phone option in your escalation policies.&#x20;
-
-When you get a phone, you can choose to take actions against an incident.&#x20;
-
-1. Press **4** to acknowledge&#x20;
-2. Press **6** to resolve&#x20;
+1. Press **4** to acknowledge
+2. Press **6** to resolve
 3. Press **9** to escalate
 
+<figure><img src="../.gitbook/assets/image (2) (1) (1).png" alt="Phone alerts from Spike"><figcaption><p>Phone alerts from Spike.</p></figcaption></figure>
+
+Check if your country or region supports phone calls on the [geo permissions page](https://app.spike.sh/geo-permissions).
+
 {% hint style="info" %}
-Make sure to verify your phone number. You can also change the phone number in settings
+Make sure to verify your phone number before setting up phone alerts. You can update it in your [profile settings](https://app.spike.sh/settings/profile).
 {% endhint %}
-
-![Phone alerts from Spike](<../.gitbook/assets/image (2) (1) (1).png>)
-
-Check if your country/region supports phone calls and SMS [on this page](https://app.spike.sh/geo-permissions).

--- a/alerts/pushover.md
+++ b/alerts/pushover.md
@@ -1,39 +1,49 @@
 ---
-description: >-
-  Our Pushover integration enables you to receive phone notification via
-  Pushover app‌
+description: Spike sends incident and on-call alerts to your phone via Pushover.
 ---
 
 # Pushover
 
-## Mobile push notifications
+[Pushover](https://pushover.net) delivers Spike alerts as mobile push notifications. Add Pushover to your escalation policies to start receiving alerts.
 
-With [Pushover](https://pushover.net), you can get alerts via Mobile push notifications by connecting and add Pushover to your escalation policy
+You can receive Pushover alerts for:
 
-You can get Pushover alerts for - 
-1. Incidents & escalations
-2. On-call shift start and end
+- Incidents
+- On-call shift start
+- On-call shift end
 
 {% hint style="info" %}
-Spike triggers Pushover alerts are "high" priority so they bypass your Do not disturb settings.
+For high-priority incidents, you can configure to get Pushover notifications even in Do Not Disturb (DND) mode.
 {% endhint %}
 
-**Connect Pushover**
+## Connect Pushover
 
-![Connect Pushover in account settings](<../.gitbook/assets/Group 2 (4).png>)
-‌
-Alert via Pushover at the time of creating an escalation policy.
+{% stepper %}
+{% step %}
+Visit [Settings > Alerts](https://app.spike.sh/settings/personal-alerts) and connect your Pushover account.
+{% endstep %}
+{% step %}
+Select **Pushover** in your escalation step.
+{% endstep %}
+{% step %}
+Choose a team member to alert.
+{% endstep %}
+{% endstepper %}
 
-![Alert Via Pushover](<../.gitbook/assets/Group 3 (3).png>)
+<figure><img src="../.gitbook/assets/Group 2 (4).png" alt="Connect Pushover in account settings"><figcaption><p>Connect Pushover in account settings.</p></figcaption></figure>
 
-**​How do I disconnect Pushover?**
+<figure><img src="../.gitbook/assets/Group 3 (3).png" alt="Add Pushover to an escalation policy"><figcaption><p>Add Pushover as a step in your escalation policy.</p></figcaption></figure>
 
-Visit [Settings](https://app.spike.sh/settings/personal-alerts) on Spike.sh to disconnect Pushover. Once disconnected, you will not get any push notification from us.
+## Disconnect Pushover
 
-**Can I assign Pushover to Oncall?**
+Visit [Settings](https://app.spike.sh/settings/personal-alerts) to disconnect Pushover. Once disconnected, Pushover alerts will stop.
 
-You can but we don't recommend it since every on-call person now and in the future must have Pushover connected to Spike.sh
+## FAQs
 
-**Is there a limit to a number of push notifications?**
+### Can I use Pushover for on-call alerts?
 
-None.&#x20;
+You can, but every on-call team member must have Pushover connected to Spike for it to work reliably.
+
+### Is there a limit on push notifications?
+
+No.

--- a/alerts/slack.md
+++ b/alerts/slack.md
@@ -1,19 +1,20 @@
 ---
-description: >-
-  The Spike app for Slack sends incident and on-call alerts to your channels and offers slash commands for creating incidents and checking on-call responders.
+description: The Spike app for Slack sends incident and on-call alerts to your channels. Use slash commands to create incidents and check on-call responders.
 ---
 
-<figure><img src="../.gitbook/assets/slack/cover.png" alt=""><figcaption></figcaption></figure>
+# Slack alerts
 
-# Introduction
+<figure><img src="../.gitbook/assets/slack/cover.png" alt="Spike app for Slack"><figcaption><p>Spike app for Slack.</p></figcaption></figure>
+
 The Spike app for Slack keeps your team informed and responsive during incidents.
 
-Key features include:
--	Incident alerts and acknowledge / resolve / escalate them
--	On-Call shift notifications
--	Private channel support
--	Create incidents directly from Slack
--	View currently on-call responders
+Key features:
+
+- Incident alerts with acknowledge, resolve, and escalate actions
+- On-call shift notifications
+- Private channel support
+- Create incidents directly from Slack
+- View current on-call responders
 
 {% tabs %}
 {% tab title="Quick links" %}
@@ -24,235 +25,160 @@ Key features include:
 {% endtab %}
 {% endtabs %}
 
-# How to set up
-Visit the [Alerts section](https://app.spike.sh/settings/general/alerts) in settings and click on **Add to Slack.**
+## How to set up
+
+Visit the [Alerts section](https://app.spike.sh/settings/general/alerts) in settings and click **Add to Slack**.
 
 {% tabs %}
 {% tab title="Setting up incident alerts" %}
-<figure><img src="../.gitbook/assets/slack/add-slack-to-escalation.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/slack/add-slack-to-escalation.png" alt="Adding Slack to an escalation policy"><figcaption><p>Adding Slack to an escalation policy.</p></figcaption></figure>
 
-Visit the [Alerts section](https://app.spike.sh/settings/general/alerts) inside your settings and click on **Add to Slack.** Our Slack app asks for some basic permissions. 
+Visit the [Alerts section](https://app.spike.sh/settings/general/alerts) in settings and click **Add to Slack**. The Spike app requests some basic permissions.
 
-Add Slack as a step in your [escalation policy](https://app.spike.sh/escalations) to get incident notifications. You can choose between public or private channels for these alerts.
+Add Slack as a step in your [escalation policy](https://app.spike.sh/escalations) to receive incident alerts. You can choose between public or private channels.
 {% endtab %}
 
 {% tab title="Setting On-call shift notifications" %}
-<figure><img src="../.gitbook/assets/slack/slack-oncall-alert.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/slack/slack-oncall-alert.png" alt="On-call shift notifications on Slack"><figcaption><p>On-call shift notifications on Slack.</p></figcaption></figure>
 
 Visit [Settings > Alerts](https://app.spike.sh/settings/general/alerts) to select Slack channels to receive on-call shift alerts.
 {% endtab %}
 
 {% tab title="Connect for DMs" %}
-* Other team members can also link their Slack accounts to receive direct messages for important updates.
-* Run the `/connect` command to connect
+* Other team members can link their Slack accounts to receive direct messages for important updates.
+* Run the `/connect` command to connect.
 {% endtab %}
-
 {% endtabs %}
 
-Use the `/help` command on Slack for further help. Spike app cannot read any of your messages on Slack
+Use the `/help` command in Slack for further help. The Spike app cannot read any of your messages.
 
----
+## Slash commands
 
-# Slash commands
+<figure><img src="../.gitbook/assets/slack/slash-commands.png" alt="Slash commands for the Spike app on Slack"><figcaption><p>Slash commands available in the Spike app.</p></figcaption></figure>
 
-<figure><img src="../.gitbook/assets/slack/slash-commands.png" alt=""><figcaption></figcaption></figure>
+1. `/create-incident`: Create a new incident directly from Slack. Anyone in your workspace can use this.
+2. `/oncall now` or `/oncall me`: Check who is currently on-call or view your on-call schedule.
+3. `/connect`: Connect your Slack account with Spike.
+4. `/help`: Display a help message with guidance on using the Spike app.
 
-Here are all the available `/slash` commands - 
+### Create incidents from Slack
 
-1. `/create-incident`
-Create a new incident directly from Slack. Anyone in your workspace can use this command.
-
-2. `/oncall now` or `/oncall me`
-Check who is currently on-call or view your on-call schedule.
-
-3. `/connect`
-Connects your Slack account in the workspace with Spike.
-
-4. `/help`
-Display a help message with guidance on using the Spike app in Slack.
-
-## Create incidents from Slack
-Using the `/create-incident` command in Slack opens an intuitive view to create incidents directly from your workspace. Here's how:
+Using `/create-incident` opens a form to create incidents directly from Slack.
 
 {% stepper %}
 {% step %}
-### Add a Title and Details
-Provide a clear and meaningful title along with relevant details, including JSON data or links if applicable.
+### Add a title and details
+Provide a clear title and relevant details, including JSON data or links if applicable.
 {% endstep %}
-
 {% step %}
-### Select Integration and Escalation Policy
-Choose the appropriate integration and escalation policy to ensure the incident is routed correctly.
+### Select integration and escalation policy
+Choose the integration and escalation policy to route the incident correctly.
 {% endstep %}
-
 {% step %}
 ### Submit
-Click to create the incident. It's that simple!
+Click to create the incident.
 {% endstep %}
 {% endstepper %}
 
 {% hint style="info" %}
-Anyone in your Slack workspace can create incidents. This makes it easier for your entire team to report issues, even if they are not part of your Spike account.
+Anyone in your Slack workspace can create incidents, even if they are not part of your Spike account.
 {% endhint %}
 
----
+## Incident alerts
 
-# Incident Alerts
-<figure><img src="../.gitbook/assets/slack/slack-incident-alert-hero.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/slack/slack-incident-alert-hero.png" alt="Incident alert on Slack"><figcaption><p>Incident alert on Slack.</p></figcaption></figure>
 
-Spike's incident alerts will mention `@here` to notify everyone online on the channel. The incident contains some key details like Title, Responders, Links, and Integration.
+Spike's incident alerts mention `@here` to notify everyone online in the channel. Each alert includes the title, responders, links, and integration.
 
-Available Actions for Each Incident
-1. __Acknowledge__
-2. __Resolve__
-3. __Escalate__
-4. __Discuss in a New Channel__
+### Available actions
 
-{% hint style="info" }
-Visit the [Alerts section](https://app.spike.sh/settings/general/alerts) inside your settings and click on Add to Slack. Our Slack app asks for some basic permissions.
+- **Acknowledge**
+- **Resolve**
+- **Escalate**
+- **Discuss in a new channel**
 
-Add Slack as a step in your [escalation policy](https://app.spike.sh/escalations) to get incident notifications. You can choose between public or private channels for these alerts.
-{% endhint %}
+### Discuss in a new channel
 
-## Discussing in a new channel
-<figure><img src="../.gitbook/assets/slack/slack-discuss-in-new-channel.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/slack/slack-discuss-in-new-channel.png" alt="Discuss incident in a new Slack channel"><figcaption><p>Discuss an incident in a dedicated Slack channel.</p></figcaption></figure>
 
-Each incident includes the option to discuss in a new channel. When this action is initiated, a dedicated channel is created for collaboration on resolving the incident. Initially, only the user who initiates the action will be added to the new channel.
+Each incident includes the option to discuss in a new channel. When triggered, a dedicated channel is created for the incident. Only the user who initiates the action is added initially. Spike cannot read messages in these channels.
 
-Spike does not have access to read messages in these channels, maintaining your privacy.
+### Auto-updating Slack messages
 
-<details>
-<summary>Who can create these channels?</summary> 
-Anyone in your workspace can initiate this action and create new channels.
-</details>
+When an incident is resolved via phone, SMS, email, or the dashboard, the Slack message updates automatically to reflect the resolved status.
 
-<details>
-<summary>Can the same channel be reused for multiple incidents?</summary> 
-No, a new channel is created for each incident to keep discussions organized and focused.
-</details>
+<figure><img src="../.gitbook/assets/slack/incident-was-already-resolved.png" alt="Slack message showing incident already resolved"><figcaption><p>The Spike app notifies you if the incident was already resolved elsewhere.</p></figcaption></figure>
 
-<details>
-<summary>What happens to the channel after the incident is resolved?</summary> 
-The channel remains in your workspace until it is manually archived. We recommend archiving the channel after resolving the incident to keep your workspace tidy.
-</details>
+If you try to resolve an incident on Slack that has already been resolved elsewhere, the app notifies you.
 
-<details>
-<summary>Can non-Spike users participate in the channel?</summary> 
-Yes, anyone in your workspace can be invited to join the discussion, regardless of their Spike account status.
-</details>
+## Private channels
 
-{% hint style="info" %}
-We recommend archiving the channel once the incident is resolved to prevent stale channels in your workspace.
-{% endhint %}
-
-## Auto-Updating Slack messages
-
-If a Slack alert has been sent for a new incident and it is resolved—whether automatically, via Phone, SMS, Email, or the Dashboard—the Slack message will automatically update to reflect the resolved status, eliminating any ambiguity about the incident’s state.
-
-<details>
-<summary>Will the Slack message update if an incident is resolved automatically?</summary>
-Yes, the Slack message will automatically update to show the resolved status.
-</details>
-
-<details>
-<summary>What if I try to resolve an incident on Slack that has already been resolved elsewhere?</summary>
-<figure><img src="../.gitbook/assets/slack/incident-was-already-resolved.png" alt=""><figcaption></figcaption></figure>
-The Slack app will notify you that the incident has already been resolved, preventing duplicate actions.
-</details>
-
----
-
-## Private channels setup
-Private channels access can be configured in [Settings > Alerts](https://app.spike.sh/settings/general/alerts)
+Private channel access can be configured in [Settings > Alerts](https://app.spike.sh/settings/general/alerts).
 
 ### Adding private channels to escalations
 
-When managing escalations, only users who have connected their Slack account with Spike can view private channels. However, they can only access private channels that:
+Only users who have connected their Slack account with Spike can view private channels in escalations. They can only see channels where:
 
-1.	They are a member of.
-2.	The `@Spike.sh` app has been added to.
-
-Both the user and the `@Spike.sh` app must be part of the private channel for it to appear under escalations.
+1. They are a member.
+2. The `@Spike.sh` app has been added.
 
 {% hint style="warning" %}
-To continue to receive alerts on your private Slack channels, it is important to add the `@Spike.sh app` to those channels. __This step is mandatory__, particularly for escalations configured before 11th December 2024, as alerts will not be delivered without the bot being added.
+Add the `@Spike.sh` app to your private channels to continue receiving alerts. This is mandatory for escalations configured before 11th December 2024.
 {% endhint %}
 
-### Private channel visibility in escalations
+### Private channel visibility
 
 Once a private channel is added to an escalation, its name is visible only to users who:
 
-1.	Have connected their Slack account with Spike.
-2.	Are members of the same private channel.
+1. Have connected their Slack account with Spike.
+2. Are members of the same private channel.
 
-Users without these permissions will not see the private channel name, ensuring enhanced privacy.
+## On-call alerts
 
-<details>
-<summary>I can’t find a channel in the dropdown. What should I do?</summary>
-You can find the channel by pasting its ID from Slack. To locate the channel ID, open the channel, go to the About section, and find the unique ID.
-<figure><img src="../.gitbook/assets/slack/find-slack-channel-id.png" alt=""><figcaption></figcaption></figure>
-</details>
+<figure><img src="../.gitbook/assets/slack/slack-oncall-alert.png" alt="On-call shift alerts on Slack"><figcaption><p>On-call shift alerts on Slack.</p></figcaption></figure>
 
-<details>
-<summary>Why can’t I see a private channel in the escalation dropdown?</summary> 
-You must be a member of the private channel and have connected your Slack account with Spike. Additionally, the `@Spike.sh` app must be added to the private channel.
-
-To connect, run the `/connect` command on Slack
-</details>
-
-<details>
-<summary>Can all team members view the private channels added to escalations?</summary> 
-No, only users who are members of the private channel and have connected their Slack account with Spike can view its name in escalations.
-</details>
-
-<details>
-<summary>How do I add the @Spike.sh app to a private channel?</summary> 
-Invite by typing `/invite @Spike.sh` in the channel.
-</details>
-
-<details>
-<summary>Can I add a private channel to escalations without connecting my Slack account?</summary> 
-No, your Slack account must be connected to Spike to add or view private channels in escalations.
-</details>
-
-<details>
-<summary>What happens if I disconnect my Slack account after adding private channels to escalations?</summary> 
-You will no longer be able to view the private channel names in escalations, even if you are a member of those channels.
-</details>
-
-<details>
-<summary>Can I see private channels added by other users in the escalation policy?</summary> 
-Only if you are a member of the same private channel and have your Slack account connected to Spike.
-</details>
-
-<details>
-<summary>What if I’m an admin on Slack but not a member of the private channel?</summary> 
-Admin privileges on Slack do not grant visibility to private channels unless you are explicitly added as a member of the channel.
-</details>
-
----
-# On-call alerts
-
-<figure><img src="../.gitbook/assets/slack/slack-oncall-alert.png" alt=""><figcaption></figcaption></figure>
-
-Visit [Settings > Alerts](https://app.spike.sh/settings/general/alerts) to select Slack channels to receive on-call shift alerts.
-
-You can enable notifications for both shift start and shift end.
-
----
+Visit [Settings > Alerts](https://app.spike.sh/settings/general/alerts) to select Slack channels to receive on-call shift alerts. You can enable notifications for both shift start and shift end.
 
 ## FAQs
 
-<details> 
-<summary>Can anyone create an incident? Is there an extra charge?</summary>
-No, anyone can create an incident, and there is no additional cost.
-</details>
+### Can anyone create an incident from Slack? Is there an extra charge?
 
-<details> 
-<summary>User A and B are part of a private channel in the escalation policy, but B can’t see the channel name in Escalation. Why?
-</summary>
-This happens when User B hasn’t connected their Slack account with Spike. To connect, they can:
-- Search for the Spike.sh bot in Slack and send a direct message to connect.
-- Run the `/connect` command to connect
-</details>
+No. Anyone in your workspace can create an incident and there is no additional cost.
 
+### I can't find a channel in the dropdown. What should I do?
+
+Paste the channel ID from Slack. To find it, open the channel, go to the **About** section, and copy the unique ID.
+
+<figure><img src="../.gitbook/assets/slack/find-slack-channel-id.png" alt="Finding a Slack channel ID"><figcaption><p>Find the channel ID in the About section.</p></figcaption></figure>
+
+### Why can't I see a private channel in the escalation dropdown?
+
+You must be a member of the private channel, have connected your Slack account with Spike, and the `@Spike.sh` app must be added to that channel. Run `/connect` on Slack to connect your account.
+
+### How do I add the @Spike.sh app to a private channel?
+
+Type `/invite @Spike.sh` in the channel.
+
+### Can all team members view private channels added to escalations?
+
+No. Only users who are members of the private channel and have connected their Slack account with Spike can see it in escalations.
+
+### Can the same discussion channel be reused for multiple incidents?
+
+No. A new channel is created for each incident to keep discussions separate.
+
+### What happens to a discussion channel after the incident is resolved?
+
+The channel stays in your workspace until manually archived. Archive it after the incident is resolved to keep your workspace tidy.
+
+### Can non-Spike users join a discussion channel?
+
+Yes. Anyone in your workspace can be invited to join, regardless of their Spike account status.
+
+### What happens if I disconnect my Slack account after adding private channels to escalations?
+
+You will no longer see the private channel names in escalations, even if you are still a member of those channels.
+
+### User A and B are in a private channel in the escalation policy, but B can't see the channel name. Why?
+
+User B hasn't connected their Slack account with Spike. They can run `/connect` in Slack or send a direct message to the Spike bot to connect.

--- a/alerts/sms.md
+++ b/alerts/sms.md
@@ -4,7 +4,7 @@ description: SMS alerts keep you informed of incidents without a phone call.
 
 # SMS alerts
 
-Spike sends an SMS when an incident triggers. SMS alerts are supported for all regions.
+Spike sends an SMS when an incident triggers.
 
 <figure><img src="../.gitbook/assets/SMS-on-Spike-sh.png" alt="SMS alerts from Spike"><figcaption><p>SMS alerts from Spike.</p></figcaption></figure>
 

--- a/alerts/sms.md
+++ b/alerts/sms.md
@@ -1,13 +1,18 @@
 ---
-description: SMS alerts from Spike.sh. Not all incidents need a phone call to wake you up.
+description: SMS alerts keep you informed of incidents without a phone call.
 ---
 
-# SMS
+# SMS alerts
 
-## Get SMS alerts
+Spike sends an SMS when an incident triggers. SMS alerts are supported for all regions.
 
-SMS alerts are now supported for all regions. Please note that currently, you _cannot_ change the status of an incident by replying.&#x20;
+<figure><img src="../.gitbook/assets/SMS-on-Spike-sh.png" alt="SMS alerts from Spike"><figcaption><p>SMS alerts from Spike.</p></figcaption></figure>
 
-![SMS alerts on Spike.sh](../.gitbook/assets/SMS-on-Spike-sh.png)
+## Change incident status via SMS
 
-Check if your country/region supports phone calls and SMS [on this page](https://app.spike.sh/geo-permissions).
+You can acknowledge or resolve an incident by sending an SMS from your registered phone number. Send a new message (not a reply) with the incident ID:
+
+1. **#\<incident\_id> ack** to acknowledge (example: `#1226 ack`)
+2. **#\<incident\_id> res** to resolve (example: `#2071 res`)
+
+Check if your country or region supports SMS on the [geo permissions page](https://app.spike.sh/geo-permissions).

--- a/alerts/telegram.md
+++ b/alerts/telegram.md
@@ -1,36 +1,25 @@
 ---
-description: Get incident alerts and on-call shifts alerts in your DM on Telegram
+description: Get incident alerts and on-call shift notifications on Telegram. Acknowledge or resolve incidents with a simple command.
 ---
 
 # Telegram
 
-## Telegram notifications
+Spike's Telegram bot is [@SpikeHQ\_bot](https://t.me/SpikeHQ\_bot). Run `/connect` to link your Spike account and start receiving alerts.
 
-Telegram bots are super nice with great control to it's users. The convenience factor has driven us to build a Telegram bot too.
+You can receive alerts for:
 
-[We are @SpikedHQ\_bot on Telegram](https://t.me/SpikeHQ\_bot)
+- New incidents
+- On-call shift start
+- On-call shift end
 
-You can instantly start a conversation with our bot to connect and start receiving alerts. You can use our Telegram bot to -
+<figure><img src="../.gitbook/assets/Screenshot from 2022-07-22 12-34-47.png" alt="Incident alert on Telegram from Spike"><figcaption><p>Incident alert on Telegram.</p></figcaption></figure>
 
-1. Receive alerts for&#x20;
-   1. Incidents. You can now add Telegram in escalation policies.
-   2. On-call shifts. Get shift start and end alerts in your account settings
-2. Acknowledge and resolve any of your incidents
-
-
-
-Use `/connect` command to connect Telegram with your Spike.sh account.
+Add Telegram to your [escalation policies](https://app.spike.sh/escalations) to receive incident alerts. For on-call shift alerts, visit [On-call settings](https://app.spike.sh/settings/personal-on-call).
 
 {% hint style="success" %}
-Use `/ack` or `/acknowledge` to acknowledge any incident. Similarly, you can use `/res` or `/resolve` to resolve any incident.
+Use `/ack` or `/acknowledge` to acknowledge an incident. Use `/res` or `/resolve` to resolve one.
 {% endhint %}
 
-
-
-![Just a taste of how incident alerts on Telegram look like](<../.gitbook/assets/Screenshot from 2022-07-22 12-34-47.png>)
-
-To start receiving on-call shift alerts, visit Settings > Account > On-call notifications or [click here](https://app.spike.sh/settings/personal-on-call)
-
-__
-
-_ps: You can connect Telegram to only one Spike.sh account_
+{% hint style="info" %}
+Telegram can only be connected to one Spike account at a time.
+{% endhint %}

--- a/alerts/title-remapper.md
+++ b/alerts/title-remapper.md
@@ -1,87 +1,73 @@
 ---
-description: >-
-  Title Remapper empowers you to programmatically change incident title in
-  real-time for better context.
+description: Title Remapper programmatically rewrites incident titles in real-time using payload data from your integrations.
 ---
 
 # Title Remapper
 
-Title Remapper empowers you to programmatically change incident title in real-time for better context. More context in alerts means it's easier and faster for responders to understand the incident better.
+Title Remapper programmatically rewrites incident titles using HandlebarsJS templates and the payload your integration sends. Use it to add context like a project name or environment, so responders immediately understand what's happening.
 
-### Example
-
-Let's take Sentry as an example. The incident title is clear but it will do us as incident responders better if we add the project name. Just makes it tad bit clear.
-
-**Without Title remapper**
+**Without Title Remapper**
 
 ```
 var temp is not defined
 ```
 
-**With Title remappe**r
+**With Title Remapper**
 
 ```
 var temp is not defined for Notification service
 ```
 
-See the difference? it immediately adds more context. So much nicer to get this additional info especially on phone call and sms alerts.
+## How to set up
 
-This was achieved by creating a Title remapper with the code below and simply templating your message from the payload your integration sends.&#x20;
+{% stepper %}
+{% step %}
+### Create a new remapper
 
-_You can read our_ [_detailed blog_](https://spike.sh/blog/title-remapper/) _on how we came about building this feature alongside the decision for HandlebarsJS._
+From the Alerts menu, go to **Title Remapper** and create a new remapper.
 
-### Getting started
+<figure><img src="../.gitbook/assets/image (142).png" alt="Creating a new Title Remapper"><figcaption><p>Create a new Title Remapper.</p></figcaption></figure>
+{% endstep %}
+{% step %}
+### Name your remapper
 
-You can write parsing logic using HandlebarsJS syntax and formulate incident titles accordingly. Read more [here](https://handlebarsjs.com/guide/#what-is-handlebars) (it's extremely simple to get started)\
+Provide a name and description for the remapper.
 
+<figure><img src="../.gitbook/assets/image (150).png" alt="Naming the Title Remapper"><figcaption><p>Name and describe your remapper.</p></figcaption></figure>
+{% endstep %}
+{% step %}
+### Select an integration
 
-#### Step 1
+Choose the integration whose payload you want to parse.
 
-From the Alerts menu, go to title remapper and create a new remapper.
+<figure><img src="../.gitbook/assets/image (143).png" alt="Selecting an integration for Title Remapper"><figcaption><p>Select an integration to see its payload.</p></figcaption></figure>
 
-![](<../.gitbook/assets/image (142).png>)
-
-#### Step 2
-
-Provide a suitable name and description for your title remapper.
-
-![](<../.gitbook/assets/image (150).png>)
-
-
-
-#### Step 3
-
-Select an integration for which you want to parse the title.
-
-![](<../.gitbook/assets/image (143).png>)
-
-Once you select an integration, a JSON body will be displayed in the preview section.
-
-This payload is the metadata which we receive from the selected integration. Using this payload, you can now write a custom parser in the code editor provided on the left.
-
-Once you have written the parser, press `Try Now` to check if the parser works and if the parsed incident title is meeting your requirements. Hit save to continue.
+Spike displays the integration's JSON payload in the preview section. Write your HandlebarsJS parser in the code editor on the left. Press **Try Now** to test the output, then hit **Save**.
 
 {% hint style="danger" %}
-Avoid #each and #unless or basically all for.. loops
+Avoid `#each`, `#unless`, and any other loop constructs in your parser.
 {% endhint %}
+{% endstep %}
+{% step %}
+### Connect integrations
 
-#### Step 4
+Select all integrations to link with this remapper.
 
-Select all the integrations to be connected with the title remapper.
+<figure><img src="../.gitbook/assets/image (144).png" alt="Connecting integrations to the Title Remapper"><figcaption><p>Connect integrations to your remapper.</p></figcaption></figure>
+{% endstep %}
+{% endstepper %}
 
-![](<../.gitbook/assets/image (144).png>)
+## Caveats
 
-### Caveats
+1. One Title Remapper can be linked to multiple integrations.
+2. Link a remapper only to integrations it was built for. Linking a remapper built for AWS to a non-AWS integration can cause errors and missing titles.
+3. If multiple Title Remappers are linked to the same integration, only the last linked remapper applies.
 
-1. One Title remapper can be linked to multiple integrations.
-2. Ensure to link a remapper created for, say AWS, to only be linked with other AWS integrations. If not, there could be errors and your title will be missing
-3. If you link multiple Title remappers to an integration, only the last linked remapper will be taken into consideration.
+## Examples
 
-### Examples
+All below examples use this payload:
 
-All examples below are showcased with the below payload.
-
-```
+```json
 data: {
   "body": {
     "event_definition_id": "this-is-a-test-notification",
@@ -122,42 +108,37 @@ data: {
 }
 ```
 
+### Basic
 
-
-#### For basic control
-
-1. **Just the message**
+**Just the message**
 
 ```
 {{data.message}}
 ```
 
-_output_ - Notification test message triggered from user \<richard>
+Output: `Notification test message triggered from user <richard>`
 
-
-
-2\. **Get event**
+**Get event title**
 
 ```
 {{data.body.event_definition_title}}
 ```
 
-_output -_ Event Definition Test Title
+Output: `Event Definition Test Title`
 
-\
-3\. **Get mode details about the event**
+**Get more details about the event**
 
 ```
-[{{data.body.event_definition_type}}] has incident => {{data.body.event_definition_title}}output - 
+[{{data.body.event_definition_type}}] has incident => {{data.body.event_definition_title}}
 ```
 
-_output -_ \[test-dummy-v1] has incident => Event Definition Test Title
+Output: `[test-dummy-v1] has incident => Event Definition Test Title`
 
+### Advanced
 
+Use built-in HandlebarsJS helpers or the additional helpers from Spike's [Swag fork](https://github.com/spikehq/swag).
 
-#### For advanced control
-
-You can use in-built helpers provided by Handlebars JS. Alongside, we also support a number of helpful helpers on our [own fork of Swag.](https://github.com/spikehq/swag)
+**Conditional title**
 
 ```
 {{#if data.body.event_definition_desc}}
@@ -169,17 +150,14 @@ You can use in-built helpers provided by Handlebars JS. Alongside, we also suppo
 {{/if}}
 ```
 
-_output -_ Message: \[testkey] - Notification test message triggered from user \<richard>
+Output: `Message: [testkey] - Notification test message triggered from user <richard>`
 
-#### &#x20;Swag helpers example
+**Swag helpers**
 
 ```
 {{uppercase data.message}} with priority {{add data.body.event.priority 1}}
 ```
 
-_Output_\
-NOTIFICATION TEST MESSAGE TRIGGERED FROM USER \<RICHARD> with priority 3
+Output: `NOTIFICATION TEST MESSAGE TRIGGERED FROM USER <RICHARD> with priority 3`
 
-
-
-Visit our [GitHub repo](https://github.com/spikehq/swag) for more examples of Swag.\
+Visit the [Swag GitHub repo](https://github.com/spikehq/swag) for more examples.

--- a/alerts/whatsapp.md
+++ b/alerts/whatsapp.md
@@ -1,41 +1,29 @@
 ---
-description: >-
-  Get incident alerts and on-call shifts alerts in your DM on WhatsApp. You can
-  also Acknowledge and Resolve an incident without ever leaving WhatsApp
+description: Get incident alerts and on-call shift notifications on WhatsApp. Acknowledge or resolve incidents without leaving WhatsApp.
 ---
 
 # WhatsApp
 
-## WhatsApp alerts
+You can receive alerts for:
 
-![](<../.gitbook/assets/WhatsApp alerts.png>)
+- New incidents
+- Acknowledge timeout
+- On-call shift start
+- On-call shift end
 
-In the changing times, SMS has gotten full of **spam**. Getting important alerts on SMS is becoming cumbersome as well. Yikes ! who wants that?!!
+<figure><img src="../.gitbook/assets/WhatsApp alerts.png" alt="WhatsApp alerts from Spike"><figcaption><p>WhatsApp alerts from Spike.</p></figcaption></figure>
 
-Our new WhatsApp bot takes away the pain of SMS and lets you take quick actions without ever leaving WhatsApp.
+## How to set up
 
-You can receive alerts for -
+WhatsApp is enabled by default for all phone numbers. Add it to your escalation policies or configure on-call notifications in [On-call settings](https://app.spike.sh/settings/personal-on-call).
 
-* New incidents
-* Acknowledge timeout
-* When your on-call shift starts
-* When your on-call shift ends
-
-You can add WhatsApp to your escalation policies and setup on-call notifications in [On-call settings](https://app.spike.sh/settings/personal-on-call)
+<figure><img src="../.gitbook/assets/escalation-policy-with-whatsapp-and-telegram.png" alt="WhatsApp in an escalation policy"><figcaption><p>Adding WhatsApp to an escalation policy.</p></figcaption></figure>
 
 {% hint style="success" %}
-To acknowledge or resolve, you reply to our WhatsApp bot with `ack test-123` and `res test-123`
+To acknowledge or resolve an incident, reply to the Spike WhatsApp bot with `ack test-123` or `res test-123`, where `test-123` is the incident ID.
 {% endhint %}
 
-![](../.gitbook/assets/escalation-policy-with-whatsapp-and-telegram.png)
-
-
-
-### How to setup?
-
-By default, WhatsApp is enabled for all phone numbers. You can directly add it in escalation policies and voila!
-
-If WhatsApp isn't your preferred bot, may we recommend trying out our Telegram bot?!&#x20;
+If you prefer a different messaging bot, Spike also has a Telegram integration:
 
 {% content-ref url="telegram.md" %}
 [telegram.md](telegram.md)

--- a/escalations/how-to-create-an-escalation-policy.md
+++ b/escalations/how-to-create-an-escalation-policy.md
@@ -1,38 +1,41 @@
 ---
-description: Creating an escalation policy on Spike.sh is super simple and intuitive.
+description: Create an escalation policy to define who gets alerted and when during an incident.
 ---
 
-# How to create an escalation policy?
+# How to create an escalation policy
 
-Here's how to create an escalation policy on Spike.sh.
+{% stepper %}
+{% step %}
+### Go to Escalations
 
-**Step 1:** Head over the [escalations section](https://app.spike.sh/escalations) on the dashboard and click on new escalation
+Navigate to the [Escalations section](https://app.spike.sh/escalations) on the dashboard and click **New escalation**.
 
-![Select escalations from sidebar](../.gitbook/assets/howto-1.png)
+<figure><img src="../.gitbook/assets/howto-1.png" alt="Escalations section on the Spike dashboard"><figcaption><p>Select Escalations from the sidebar.</p></figcaption></figure>
+{% endstep %}
+{% step %}
+### Configure the policy
 
-**Step 2:**
+1. Give the policy a clear, identifiable name.
+2. Add one or more escalation levels.
+3. Set a timeout for each level. This is how long Spike waits before escalating to the next level if the incident isn't acknowledged or resolved.
 
-1. Make sure to give a good identifiable name based on the team members in it.
-2. Add multiple escalation levels
-3. Add a **time to wait** before automatically escalating if incident is open (not acknowledged or resolved)
-4. Save
-
-{% hint style="info" %}
-
-{% endhint %}
-
-![An example escalation policy ](<../.gitbook/assets/howto-2 (1).png>)
+<figure><img src="../.gitbook/assets/howto-2 (1).png" alt="An example escalation policy in Spike"><figcaption><p>An example escalation policy with two levels.</p></figcaption></figure>
 
 {% hint style="info" %}
-Avoid adding any time interval for the last step where escalation ends.&#x20;
+Leave the time interval blank on the last escalation step.
 {% endhint %}
+{% endstep %}
+{% step %}
+### Save
 
-## Caveats
+Click **Save** to activate the policy.
+{% endstep %}
+{% endstepper %}
 
-### Simultaneous alerts
+## Simultaneous alerts
 
-If you would like to receive simultaneous alerts for either you, your team or Slack, Teams, etc then we highly recommend adding multiple alerts in one escalation step vs creating another step with 0 minutes as interval.&#x20;
+To alert multiple people or channels at the same time, add them as separate alerts within the same escalation level. Avoid creating a new escalation level with a 0-minute interval. This is not the same as simultaneous alerting.
 
-![Avoid 0 minutes interval](../.gitbook/assets/simultaneous-alerts-wrong.png)
+<figure><img src="../.gitbook/assets/simultaneous-alerts-wrong.png" alt="Incorrect: separate escalation level with 0-minute interval"><figcaption><p>Incorrect: a separate level with 0-minute interval.</p></figcaption></figure>
 
-![](../.gitbook/assets/simultaneous-alerts-right.png)
+<figure><img src="../.gitbook/assets/simultaneous-alerts-right.png" alt="Correct: multiple alerts within the same escalation level"><figcaption><p>Correct: multiple alerts within one escalation level.</p></figcaption></figure>

--- a/escalations/how-to-create-an-escalation-policy.md
+++ b/escalations/how-to-create-an-escalation-policy.md
@@ -4,6 +4,10 @@ description: Create an escalation policy to define who gets alerted and when dur
 
 # How to create an escalation policy
 
+{% hint style="info" %}
+Not sure where to start? Spike offers [escalation policy templates](https://spike.sh/templates/escalation-templates) with pre-built configurations.
+{% endhint %}
+
 {% stepper %}
 {% step %}
 ### Go to Escalations

--- a/escalations/introduction-to-escalations.md
+++ b/escalations/introduction-to-escalations.md
@@ -1,28 +1,25 @@
-# Introduction to escalations
+---
+description: Escalation policies define who gets alerted and when, so incidents don't go unacknowledged.
+---
 
-## What is an escalation policy?
+# Escalation policies
 
-An escalation policy is a simple set of rules to alert the right person at the right time using the right channel such as phone, slack or email. If that person misses out then the incident gets escalated to the next person.
+An escalation policy defines who gets alerted, through which channel, and in what order. When an incident triggers, Spike follows the policy until someone acknowledges or resolves it.
 
-![](<../.gitbook/assets/escalations-list (2).png>)
+<figure><img src="../.gitbook/assets/escalations-list (2).png" alt="Escalation policies list in Spike"><figcaption><p>Escalation policies in Spike.</p></figcaption></figure>
 
-## Basics
+## How escalation policies work
 
-When an incident is triggered an escalation policy comes into affect to send alerts. Spike continues to send alerts according to the policy until someone acknowledges an incident.
+Each policy has one or more levels. After Spike sends alerts at the first level, it waits for a configured timeout before moving to the next. If no one acknowledges within that window, the incident escalates to the next level automatically.
 
-{% hint style="info" %}
-You can create unlimited escalation policies with multiple levels of escalations
-{% endhint %}
+You can alert multiple people at the same level, across different channels or the same one. You can configure the timeout between levels and create as many levels as you need.
 
-![](<../.gitbook/assets/Screenshot 2020-06-24 at 10.48.37 AM.png>)
-
-As per the above example, we have 2 levels of escalations. After the alert is sent via the first level, Spike will wait for only 5 minutes for someone to **acknowledge or resolve** the incident before automatically escalating to the next level. 
-
-You can configure the timeout (in this case, 5 minutes) between escalation levels. You can create as many escalation levels as you want. **You can choose to alert multiple people via different (or same) alert channels simultaneously**. 
+<figure><img src="../.gitbook/assets/Screenshot 2020-06-24 at 10.48.37 AM.png" alt="Escalation policy with two levels in Spike"><figcaption><p>An escalation policy with two levels and a 5-minute timeout.</p></figcaption></figure>
 
 {% hint style="info" %}
-~~At the end of escalation, they are automatically repeated.~~ 
-
-Escalations are no more repeated automatically. You will need to configure this in the integration settings. [Learn more](https://docs.spike.sh/escalations/repeat-escalations)
+Escalations don't repeat automatically. Configure repeat escalations in your integration settings. [Learn more](repeat-escalations.md)
 {% endhint %}
 
+{% hint style="info" %}
+You can create unlimited escalation policies with multiple levels.
+{% endhint %}

--- a/incidents/acknowledge-timeout.md
+++ b/incidents/acknowledge-timeout.md
@@ -1,34 +1,23 @@
 ---
-description: >-
-  Set a timeout for when an incident is acknowledged but not resolved in the
-  given time frame. Acknowledge timeout helps your team by reminding you of
-  incidents in non-resolved state
+description: Acknowledge timeout automatically moves an acknowledged incident back to triggered state if it isn't resolved within a set time.
 ---
 
 # Acknowledge timeout
 
-## What is acknowledge timeout?
+Acknowledge timeout is a time limit you set on an integration. If an acknowledged incident isn't resolved within that window, Spike moves it back to triggered state and resumes alerting. This is useful when someone acknowledges an incident but gets pulled into other work before resolving it.
 
-After acknowledging the incident, if it is not resolved in given amount of time then it will return to **triggered state**. Escalations and alerts will resume again.
+<figure><img src="../.gitbook/assets/ack-timeout.png" alt="Acknowledge timeout setting"><figcaption><p>Set acknowledge timeout in minutes on any integration.</p></figcaption></figure>
 
-Many-a-times, you or your team-mate would acknowledge an incident but never get around to resolving it for multitude of reasons. This is where the **acknowledge timeout** feature comes in handy.&#x20;
+## What timeout should you set?
 
-You can set acknowledge timeout **in minutes** to all of your new and existing integrations by editing a service or adding a new service.&#x20;
+It depends on how critical the integration is. A shorter timeout means faster re-alerting on unresolved incidents.
 
-![Acknowledge timeout](../.gitbook/assets/ack-timeout.png)
+- **Critical integrations** — 20 minutes
+- **Severe but non-critical integrations** — 60 minutes
+- **Non-critical integrations** — leave it blank
 
-### What is an ideal Acknowledge timeout?
+You don't need a timeout on every integration.
 
-This really depends on the integration. The more critical it is the shorter the timeout should be.&#x20;
-
-_Here's what we recommend -_
-
-1. Critical integration - **20 minutes**
-2. Severe but not critical integration - **60 minutes**
-3. Non-severe and non-critical integration - **Leave it blank.**
-
-You don't need an Acknowledge timeout for _every integration._&#x20;
-
-{% hint style="info" %}
-Please make sure to keep a generous timeout and **avoid keeping short times like 5 or 10 minutes**. Keeping short timeouts will end up in way too many alerts you did rather ignore.
+{% hint style="warning" %}
+Avoid short timeouts like 5 or 10 minutes. They generate more alerts than your team can act on and increase alert fatigue.
 {% endhint %}

--- a/incidents/grouping-incidents.md
+++ b/incidents/grouping-incidents.md
@@ -1,15 +1,17 @@
 ---
-description: Repeated incidents will be grouped together.
+description: Spike automatically groups repeated incidents so you can see how often an issue recurs and when it first appeared.
 ---
 
 # Grouping incidents
 
-## Group repeated incidents
+When the same incident fires multiple times, Spike groups the repeats under the original incident rather than creating new ones. This keeps your dashboard clean and gives you a clear picture of how often an issue is recurring.
 
-Spike supports automatic grouping of incidents which will be repeated. It helps give you perspective on how many times has this incident been repeated. Below is an example -
+<figure><img src="../.gitbook/assets/image (14) (1) (1).png" alt="Grouped incidents on Spike"><figcaption><p>Repeated incidents are grouped under the original with a repeat count.</p></figcaption></figure>
 
-![This "Parallel write .." has been grouped to give you some insights](<../.gitbook/assets/image (14) (1) (1).png>)
+Each grouped incident shows:
 
-### Use cases
+- How many times it has repeated
+- When it first occurred
+- When it last occurred
 
-Grouping incidents gives your context. It gives you insights of how many times it has repeated along with it's first occurrence and the last occurrence of this incident. This will help you identify if this is an incident that is truly affecting your customers and how many times it has affected in the past too. Given these stats, you should be able to prioritise this incident and work on it.
+This helps you judge whether an issue is a one-off or a pattern. If an incident has repeated dozens of times, it's likely affecting your customers and worth prioritizing over something that fired once.

--- a/incidents/grouping-incidents.md
+++ b/incidents/grouping-incidents.md
@@ -4,7 +4,7 @@ description: Spike automatically groups repeated incidents so you can see how of
 
 # Grouping incidents
 
-When the same incident fires multiple times, Spike groups the repeats under the original incident rather than creating new ones. This keeps your dashboard clean and gives you a clear picture of how often an issue is recurring.
+When the same incident fires multiple times, Spike groups them under the original incident rather than creating new ones. This keeps your dashboard clean and gives you a clear picture of how often an issue is recurring.
 
 <figure><img src="../.gitbook/assets/image (14) (1) (1).png" alt="Grouped incidents on Spike"><figcaption><p>Repeated incidents are grouped under the original with a repeat count.</p></figcaption></figure>
 
@@ -13,5 +13,6 @@ Each grouped incident shows:
 - How many times it has repeated
 - When it first occurred
 - When it last occurred
+- When each recurrence happened
 
 This helps you judge whether an issue is a one-off or a pattern. If an incident has repeated dozens of times, it's likely affecting your customers and worth prioritizing over something that fired once.

--- a/incidents/how-to-change-incident-status.md
+++ b/incidents/how-to-change-incident-status.md
@@ -1,10 +1,10 @@
 ---
-description: You can change an incident's status from the dashboard, a phone call, Slack, email, SMS, or mobile.
+description: You can change an incident's status from all alerting channels without having to come to Spike.
 ---
 
 # How to change incident status
 
-You can change an incident's status from multiple places: the dashboard, a phone call, Slack, email, SMS, or mobile.
+You can change an incident's status from all alerting channels without having to come to Spike.
 
 ## From the dashboard
 

--- a/incidents/how-to-change-incident-status.md
+++ b/incidents/how-to-change-incident-status.md
@@ -1,80 +1,59 @@
 ---
-description: >-
-  Responders can choose to change incident status on phone alerts, Slack and on
-  the dashboard.
+description: You can change an incident's status from the dashboard, a phone call, Slack, email, SMS, or mobile.
 ---
 
-# How to change incident status?
+# How to change incident status
+
+You can change an incident's status from multiple places: the dashboard, a phone call, Slack, email, SMS, or mobile.
 
 ## From the dashboard
 
-![Select one or more incidents](../.gitbook/assets/incident-status-change-new.png)
+<figure><img src="../.gitbook/assets/incident-status-change-new.png" alt="Select one or more incidents on the dashboard"><figcaption><p>Select incidents and change their status from the dashboard.</p></figcaption></figure>
 
-You will see open incidents on the [dashboard](https://app.spike.sh). Select a single incident with the checkbox on the left-hand side and hit the **Acknowledge** button on top. Similarly, you can choose to **Resolve** by using the adjacent button.
+Open the [dashboard](https://app.spike.sh) to see all open incidents. Select an incident using the checkbox on the left, then click **Acknowledge** or **Resolve** at the top.
 
 ### Multiple incidents
 
-Alternatively, you can choose multiple incidents to change status by selecting each incident or use the dropdown to quickly select all incidents that match the criteria.
+Select multiple incidents using the checkboxes, or use the dropdown to select all incidents matching a specific criteria. Then apply the status change in bulk.
 
-## From phone call
+## From a phone call
 
+<figure><img src="../.gitbook/assets/phone.png" alt="Take actions on incidents from a phone call"><figcaption><p>Use keypresses during a phone alert to change incident status.</p></figcaption></figure>
 
+During a [phone alert](../alerts/phone.md), press a key to take action immediately:
 
-![Take actions on incidents from the phone call](../.gitbook/assets/phone.png)
+1. **Press 4** to acknowledge
+2. **Press 6** to resolve
+3. **Press 9** to escalate
 
-On the phone alert, you can take immediate actions by -&#x20;
+You'll hear a voice confirmation on the same call once the status changes.
 
-1. **Press 4 to Acknowledge**
-2. **Press 6 to Resolve**
-3. **Press 9 to Escalate**
+## From Slack
 
-Phone calls are restricted to 420 characters which we believe should suffice to give you the context of the incident.&#x20;
+<figure><img src="../.gitbook/assets/slack-gif.gif" alt="Acknowledge and resolve incidents from Slack"><figcaption><p>Slack alerts include Acknowledge and Resolve buttons.</p></figcaption></figure>
 
-{% hint style="info" %}
-You will get a voice confirmation on the same call upon incident status change
-{% endhint %}
+Every [Slack alert](../alerts/slack.md) includes **Acknowledge** and **Resolve** buttons. When you change the status, all related Slack messages update to reflect it. This applies regardless of whether the change was made via phone, email, SMS, or the dashboard.
 
-## **From Slack**
+## From email
 
-All alerts on Slack will have actionable buttons to **Acknowledge** and **Resolve** incidents.
+Reply to a [Spike email alert](../alerts/email.md) with one of the following:
 
-![](../.gitbook/assets/slack-gif.gif)
+1. **#ack** to acknowledge
+2. **#res** to resolve
 
-{% hint style="info" %}
-Upon status change, the relevant Slack messages will update to reflect them. This also applies if anyone changes the status via Phone, Email, SMS, or from the Dashboard too.&#x20;
-{% endhint %}
+No confirmation is sent after the status change.
 
-## **From Email**
+## From SMS
 
-Use the following actions to change incident status directly from email by replying -&#x20;
+Send an SMS from your registered phone number to change status. You don't need to reply to a Spike message — just send a new one:
 
-1. **#res** to resolve
-2. **#ack** to acknowledge
+1. **#\<incident\_id> ack** to acknowledge (example: `#1226 ack`)
+2. **#\<incident\_id> res** to resolve (example: `#2071 res`)
 
-{% hint style="info" %}
-Upon status change, we do not send a confirmation
-{% endhint %}
+This works even if [SMS](../alerts/sms.md) is not in your escalation policy. Spike processes the action as long as you send from your registered number.
 
-## **From SMS**
+## From mobile
 
-Send Spike.sh an SMS from your registered phone number to change incident status.&#x20;
+The dashboard and incident detail pages are mobile-compatible. Visit [app.spike.sh](https://app.spike.sh) on your mobile browser to view open incidents and change their status.
 
-1. **#\<incident\_id> res** to resolve. (example: #2071 res)
-2. **#\<incident\_id> ack** to acknowledge. (example: #1226 ack)
-
-The SMS action doesn't depend on replying to our message. It only relies on you sending us a message. This means if you don't have SMS in your escalation policy and then choose to perform the above action, it would still work.&#x20;
-
-{% hint style="info" %}
-Upon status change, we do not send a confirmation
-{% endhint %}
-
-## From mobile website
-
-Our dashboard page and incident details page are mobile compatible. You can check open incidents and relevant incidents on your mobile and change incident statuses.&#x20;
-
-![Incident page on mobile](<../.gitbook/assets/image (73).png>)
-
-{% hint style="info" %}
-visit [https://app.spike.sh](https://app.spike.sh) on mobile to access the dashboard.
-{% endhint %}
-
+<figure><img src="../.gitbook/assets/image (73).png" alt="Incident page on mobile"><figcaption><p>View and manage incidents from your mobile browser.</p></figcaption></figure>

--- a/incidents/incident-lifecycle.md
+++ b/incidents/incident-lifecycle.md
@@ -1,45 +1,36 @@
 ---
-description: Lifecycle of an incident.
+description: The incident lifecycle covers the stages an incident moves through, from the moment it's triggered to when it's resolved.
 ---
 
 # Incident lifecycle
 
-## Incident lifecycle
+Every incident on Spike moves through a defined set of stages. Understanding this flow helps you configure escalation policies, acknowledge timeouts, and alert channels to match how your team actually responds.
 
-Incidents can have one of these statuses -
+<figure><img src="../.gitbook/assets/Incident lifecycle.png" alt="Incident lifecycle on Spike"><figcaption><p>The stages of an incident on Spike.</p></figcaption></figure>
 
-1. **Triggered**
-2. **Acknowledged**
-3. **Resolved**
+## 1. Incident creation
 
-_Learn more about what these states in the next page_
+An incident is created when a connected integration sends a webhook to Spike. Before creating a new incident, Spike checks whether an open incident already exists for that integration.
 
-![](<../.gitbook/assets/Incident lifecycle.png>)
-
-### 1. Triggering incidents
-
-Your added integrations will create an incident on Spike. Every integration on one or more services are treated uniquely. This would mean that you can have multiple AWS integrations and they will all be treated uniquely to make sure that incidents are triggered.
-
-Before the incident is created, Spike checks for similar incidents for this integration. If it exists then _a new incident is not created but an event is logged for the same incident which is not resolved._
+- If one exists, Spike logs the new event under the existing incident instead of creating a duplicate.
+- If no open incident exists, Spike creates a new one and starts the escalation process.
 
 {% hint style="info" %}
-**Avoiding duplication of incidents**.
-
-Similar incidents in resolved state are ignored. Only the incidents which are **open (acknowledged or triggered state)** will be checked.
+Only open incidents (triggered or acknowledged) are checked for duplicates. Resolved incidents are ignored.
 {% endhint %}
 
-### 2. Automatic escalations
+## 2. Incident escalation
 
-On Spike, you have the freedom to assign a separate escalation policy to each of your integration. This gives you the flexibility to operate with ease knowing which alerts to prioritise over others.
+Once an incident is created, Spike works through the [escalation policy](../escalations/introduction-to-escalations.md) attached to that integration. Alerts go out to the first set of responders in the policy. Spike waits for the duration configured in the escalation policy. If no one acknowledges or resolves the incident in that time, Spike moves to the next level and alerts the next set of responders.
 
-![Example escalation policy on spike.sh](<../.gitbook/assets/screenshot-2020-06-24-at-10.48.37-am (1).png>)
+Each integration can have its own escalation policy. This lets you set different alert priorities across services.
 
-Spike alerts based on the escalation policy. For the newly created incident, the first alert is sent in the order of responders in the policy. In the above example, the first alert is being sent to the **Slack channel #incidents** along with alerting dev member Kaushik and email to another member.
+## 3. Incident acknowledgment
 
-Spike waits for 5 minutes for the any of the responders to acknowledge or resolve the incident. If there is no action taken, spike automatically escalates and alerts the responders on the next level.
+When a responder acknowledges the incident, Spike pauses the escalation policy and stops sending alerts. You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration: a time limit that moves the incident back to triggered and resumes alerting if it hasn't been resolved in time.
 
-In the above examples, there are 2 responders who will be alerted via phone, also at the same time we alert to **Slack channel #dev-team**.
+## 4. Incident resolution
 
-### 3. Acknowledge timeout
+Once the issue is fixed, mark the incident as resolved. Spike stops all alerts and resets the escalation policy. If a new incident comes in for the same integration, the process starts again from the beginning.
 
-For every integration, you can choose a set a timeout for incidents acknowledged but not resolved. After this timeout, Spike resumes the escalations and start sending alerts to the next escalation level. If it's the end of escalation then it's repeated automatically.
+See [incident statuses](incident-statuses.md) for a full reference on each status.

--- a/incidents/incident-lifecycle.md
+++ b/incidents/incident-lifecycle.md
@@ -27,7 +27,7 @@ Each integration can have its own escalation policy. This lets you set different
 
 ## 3. Incident acknowledgment
 
-When a responder acknowledges the incident, Spike pauses the escalation policy and stops sending alerts. You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration: a time limit that moves the incident back to triggered and resumes alerting if it hasn't been resolved in time.
+When a responder acknowledges the incident, Spike pauses the escalation policy and stops escalating alerts. You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration: a time limit that moves the incident back to triggered and resumes alerting if it hasn't been resolved in time.
 
 ## 4. Incident resolution
 

--- a/incidents/incident-statuses.md
+++ b/incidents/incident-statuses.md
@@ -1,50 +1,25 @@
 ---
-description: >-
-  A status would determine the state of the incident among acknowledged or
-  resolved
+description: Every incident on Spike has one of three statuses: triggered, acknowledged, or resolved. The status determines what Spike does next.
 ---
 
 # Incident statuses
 
-## What are different Incident statuses?
+Every incident on Spike moves through three statuses: triggered, acknowledged, and resolved. The current status determines whether Spike is actively alerting, paused while someone works on a fix, or closed.
 
-There are mainly 3 states -&#x20;
+## Triggered
 
-1. **Triggered 🔥**
-2. **Acknowledged** 👩‍💻
-3. **Resolved** ✅
+An incident enters the triggered state the moment it's created. This means no one has looked at it yet and the problem is unresolved.
 
-### **1. Triggered 🔥**
+In this state, Spike works through the [escalation policy](../escalations/introduction-to-escalations.md) attached to the integration and sends alerts to the designated responders. Alerts continue until someone acknowledges or resolves the incident. Repeat incidents from the same integration are suppressed and logged rather than creating new ones.
 
-Every incident which comes to Spike will be first in the **triggered** state. It would mean that someone will need to look into this and address the problem.
+## Acknowledged
 
-Alerts are sent to members as long as an incident remains in this state.&#x20;
+An acknowledged incident means someone is actively working on a fix. Spike pauses the escalation policy and stops sending alerts.
 
-### 2. Acknowledged 👩‍💻
+Repeat incidents remain suppressed in this state to reduce [alert fatigue](../alerts/personal-alerts-management/README.md). You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration. If the incident isn't resolved within that window, Spike moves it back to triggered and resumes alerting.
 
-An **acknowledged** state of the incident would mean that you have begun to look into the incident. Alternatively, this also means that work to resolve this incident has begun.&#x20;
+## Resolved
 
-In this state, repeat incidents are automatically suppressed and logged reducing alert fatigue.
+A resolved incident means the issue is fixed. Spike stops all alerts and resets the escalation policy.
 
-{% hint style="info" %}
-We highly recommend setting an acknowledge timeout for all your incidents.&#x20;
-{% endhint %}
-
-{% content-ref url="acknowledge-timeout.md" %}
-[acknowledge-timeout.md](acknowledge-timeout.md)
-{% endcontent-ref %}
-
-### 3. Resolved ✅
-
-Once an incident is fixed, you mark it as **resolved**. This is the end state for all incidents.&#x20;
-
-If a similar incident is triggered then a new incident is created.
-
-
-
-
-
-
-
-
-
+If the same integration triggers a new incident after resolution, Spike treats it as a fresh incident and starts the process from the beginning. See [incident lifecycle](incident-lifecycle.md) for the full flow.

--- a/incidents/incident-statuses.md
+++ b/incidents/incident-statuses.md
@@ -8,7 +8,7 @@ Every incident on Spike moves through three statuses: triggered, acknowledged, a
 
 ## Triggered
 
-An incident enters the triggered state the moment it's created. This means no one has looked at it yet and the problem is unresolved.
+An incident enters the triggered state the moment it's triggered. This means no one has looked at it yet and the problem is unresolved.
 
 In this state, Spike works through the [escalation policy](../escalations/introduction-to-escalations.md) attached to the integration and sends alerts to the designated responders. Alerts continue until someone acknowledges or resolves the incident. Repeat incidents from the same integration are suppressed and logged rather than creating new ones.
 

--- a/incidents/incident-statuses.md
+++ b/incidents/incident-statuses.md
@@ -14,7 +14,7 @@ In this state, Spike works through the [escalation policy](../escalations/introd
 
 ## Acknowledged
 
-An acknowledged incident means someone is actively working on a fix. Spike pauses the escalation policy and stops sending alerts.
+An acknowledged incident means someone is actively working on a fix. Spike pauses the escalation policy and stops escalating alerts.
 
 Repeat incidents remain suppressed in this state to reduce [alert fatigue](../alerts/personal-alerts-management/README.md). You can set an [acknowledge timeout](acknowledge-timeout.md) for each integration. If the incident isn't resolved within that window, Spike moves it back to triggered and resumes alerting.
 

--- a/incidents/mute-alerts.md
+++ b/incidents/mute-alerts.md
@@ -1,24 +1,24 @@
 ---
-description: >-
-  Mute all alerts 🚨  (or switch off all alarms) for an incident so you can
-  continue your work fixing it.
+description: Mute alerts on an incident to stop notifications for a set period without resolving it.
 ---
 
 # Mute alerts
 
-## Mute alerts
+Muting stops all alerts for an incident and its repeated occurrences for a set period. The incident stays open and logged. Spike just stops notifying your team about it.
 
-For every **incident** **and it's repeated incidents**, you can choose to mute all alerts for a specific period of time. Following are the time options currently available -
+This is useful for low-priority incidents you're aware of but don't need to act on immediately. Instead of getting alerted repeatedly, you mute it and come back when you're ready.
 
-1. An hour
-2. 10 hours
-3. A day
-4. A week
-5. A month
-6. **Forever** - (_note: be careful with this_)
+<figure><img src="../.gitbook/assets/image (15) (1) (1).png" alt="Mute alerts on an incident"><figcaption><p>Mute alerts on an incident for a set duration.</p></figcaption></figure>
 
-![Mute alerts or switch off alarms](<../.gitbook/assets/image (15) (1) (1).png>)
+## Mute duration options
 
-### Use cases
+- 1 hour
+- 10 hours
+- 1 day
+- 1 week
+- 1 month
+- Forever
 
-Not all incidents are critical, also, not all incidents need to be worked upon instantly. For all those low handing fruits, you can now mute the alerts and just log these incidents on Spike.
+{% hint style="warning" %}
+Use **Forever** carefully. Muting an incident permanently means your team will never be alerted about it again, even if it keeps recurring.
+{% endhint %}

--- a/incidents/priority-and-severity.md
+++ b/incidents/priority-and-severity.md
@@ -1,79 +1,71 @@
 ---
-description: >-
-  Determine and set incident's priority to indicate urgency and severity to
-  indicate possible damage
+description: Priority indicates how urgently an incident needs to be resolved. Severity indicates the degree of damage to your systems.
 ---
 
-# Priority and Severity
+# Priority and severity
 
-Not all incidents are critical or need to be resolved immediately. To help understand an incident better, we bring you two critical components to every incident - **Priority, and Severity**.&#x20;
+Not all incidents need immediate action. Priority and severity give your team two ways to classify an incident: how urgent it is to fix, and how much damage it's causing.
 
 ## Priority
 
-Assign a priority to your incident to indicate the urgency to resolve it. If the incident repeats itself, the set priority will be automatically assigned.
+Priority indicates the urgency to resolve an incident. Available priorities are:
 
-Available priorities are -&#x20;
+- **P1**: Urgent
+- **P2**: High
+- **P3**: Medium
+- **P4**: Low
+- **P5**: Info
 
-* **P1** - Urgent
-* **P2** - High
-* **P3** - Medium
-* **P4** - Low
-* **P5** - Info&#x20;
-
-Setting priority is a great way to indicate to your team the urgency to fix it. Additionally, you can setup alert rules to take actions automatically when the incident repeats itself. \
-\
-**Example:**\
-****P1 **** - Billing service downtime\
-****P2 **** - DB server running out of storage space
+For example, a billing service outage is a P1. A database server running low on storage might be a P2.
 
 ## Severity
 
-Assign severity to indicate the severity of damage to your systems.&#x20;
+Severity indicates the degree of damage to your systems. Available severities are:
 
-Available severities are -
+- **SEV1**: High
+- **SEV2**: Medium
+- **SEV3**: Low
 
-* **SEV1** - High
-* **SEV2** - Medium
-* **SEV3** - Low
+For example, a data leak or full service outage is a SEV1. A degraded non-critical service might be a SEV3.
 
-Data leaks / Website service down is a good example of SEV1 - High severity.
-
-{% hint style="success" %}
-Once set, we will remember the severity and priority when the incident occurs in the future.
+{% hint style="info" %}
+Once you set priority and severity on an incident, Spike remembers them for future occurrences of the same incident.
 {% endhint %}
 
 ## Setting priority and severity
 
-There are multiple ways to assign these properties to an incident.&#x20;
+### From the dashboard
 
-### From dashboard
+Select one or more incidents. The priority, severity, and mute options appear at the top of the list.
 
-Select incidents and the options for priority, severity, and mute will be available for you.&#x20;
+<figure><img src="../.gitbook/assets/Priority on dashboard.png" alt="Set priority on multiple incidents from the dashboard"><figcaption><p>Select incidents from the dashboard to set priority and severity in bulk.</p></figcaption></figure>
 
+### From the incident page
 
+Open any incident to find the priority and severity options on the incident detail page.
 
-![Set priority on multiple incidents](<../.gitbook/assets/Priority on dashboard.png>)
+<figure><img src="../.gitbook/assets/image (81).png" alt="Set priority from the incident page"><figcaption><p>Set priority and severity directly from the incident page.</p></figcaption></figure>
 
-### From Incident page
+### From integrations
 
-You will find these options on the incident page for both priority and severity.&#x20;
+Some integrations, like Azure, send priority and severity as part of their incident payload. Spike reads these values and sets them automatically, overwriting any existing values.
 
-![Setting priority from the incident page](<../.gitbook/assets/image (81).png>)
+You can also send priority and severity via [webhook integration](../integrations-guideline/integrating-with-webhooks.md).
 
-### From integrations (automated)
+### From alert rules and Playbooks
 
-Integrations like Azure send priority and severity with their incident details. We will acknowledge this and overwrite your incident's priority and severity.
+You can set priority and severity automatically using [alert rules](../alerts/alert-rules.md) based on incident properties. [Playbooks](../playbooks/introduction-to-playbooks.md) can also set them as part of an automated response when an incident fires.
 
-{% hint style="success" %}
-You can also send priority and severity with webhook integration. [Learn more](https://docs.spike.sh/integrations-guideline/integrating-with-webhooks)
-{% endhint %}
-
-## F.A.Q
+## FAQ
 
 ### Should I set both priority and severity?
 
-It's recommended to do so, at least for critical incidents. However, if you would like, you can choose to only use one.&#x20;
+For critical incidents, yes. For lower-signal integrations, you can use just one or neither. Both fields are optional.
 
-### Who has access to set and unset?
+### Who can set priority and severity?
 
-Everyone. There is no access control because we believe tackling incidents is a team effort.&#x20;
+Everyone on the team. There are no restrictions on who can set or change these fields.
+
+### Can I set priority and severity automatically?
+
+Yes. Use [alert rules](../alerts/alert-rules.md) to set them based on incident properties, or connect integrations like Azure that send these values automatically with each incident.

--- a/incidents/rate-limiting-on-duplicate-incidents.md
+++ b/incidents/rate-limiting-on-duplicate-incidents.md
@@ -1,30 +1,33 @@
 ---
-description: Rate limiting for duplicate incidents.
+description: Spike rate-limits duplicate incidents to reduce noise when the same incident triggers repeatedly in a short window.
 ---
 
 # Rate limiting on duplicate incidents
-To avoid noise and excessive information, duplicate incidents will be rate-limited for just 1 minute. We only rate-limit an incident and **not an integration**. These are the rules - 
 
-- Trigger 20 duplicate incidents every 60 seconds (duplicate incidents will also get suppressed automatically) 
-- After the first 60 seconds, rate limiting will be applied for 1 minute
-- Rate limiting will be uplifted after one minute and duplicate incidents will be allowed
+Rate limiting kicks in when the same incident triggers too many times in a short window. It prevents your team from being overwhelmed with duplicate alerts.
 
+## How it works
 
-## F.A.Qs
-### Does this affect other incidents?
-No. Any other incident on any integration including the integration for which incident was rate-limited will not be rate-limited or affected.
+If an incident triggers 20 or more times within 60 seconds, Spike rate-limits it for one minute. During that window, duplicate incidents are suppressed. After one minute, rate limiting is lifted and new incidents from the same integration are allowed through again.
 
-### Will other incidents be triggered for the same integration?
-Yes. We rate-limit an incident, not an integration. 
+## FAQs
 
-### Will I be informed about rate limiting?
-Yes. Admins will get an email alert only when rate limiting applies. An email alert will be sent only once every 30 minutes.
+### What counts as a duplicate incident?
 
-### What are duplicate incidents?
-Spike.sh will parse a payload into human-readable format. We call this incident title. Incidents with the same title are duplicates. 
+Incidents with the same title are considered duplicates.
 
-### Is any action needed to uplift the rate limits?
-No action is needed on your end. Rate limiting is automatically set and uplifted in just one minute.
+### Does rate limiting affect other incidents?
+
+No. Rate limiting applies to a specific incident, not the integration. All other incidents on the same integration continue to trigger normally.
+
+### Will I be notified when rate limiting applies?
+
+Yes. Admins receive an email alert when rate limiting kicks in. However, Spike sends no more than one email every 30 minutes.
 
 ### Will any incidents be missed?
-No way. A duplicate incident has to be sent to your hooks endpoint a 20 times in under a minute for it to be rate-limited. You would have gotten alerts for the very first incident that was created.
+
+No. An incident has to trigger 20 or more times within 60 seconds for rate limiting to apply. You would have received an alert for the very first occurrence.
+
+### Is any action needed to lift rate limiting?
+
+No. Rate limiting is automatic. It lifts itself after one minute.

--- a/incidents/reassign-incidents.md
+++ b/incidents/reassign-incidents.md
@@ -1,33 +1,29 @@
 ---
-description: Reassign the incident to any of your team mates
+description: Reassign an incident to any team member directly from the dashboard, incident page, or service view.
 ---
 
 # Reassign incidents
 
-### How to reassign incidents?
+You can reassign any incident to a team member. Once reassigned, they receive an email notification.
 
-Select any number of incidents and click on **reassign** on the header of the incidents table. 
+## How to reassign
 
-![Reassign button on incidents table](../.gitbook/assets/reassign-button.png)
+Select one or more incidents and click **Reassign** in the incidents table header.
 
-You can reassign an incident to a team member. Not all incidents will have assignee to it, especially when you have Slack app notifying you on channels.
+<figure><img src="../.gitbook/assets/reassign-button.png" alt="Reassign button on the incidents table"><figcaption><p>The Reassign button appears in the incidents table header after selecting an incident.</p></figcaption></figure>
 
-![Reassigned incident](<../.gitbook/assets/image (39).png>)
+<figure><img src="../.gitbook/assets/image (39).png" alt="Reassigned incident"><figcaption><p>A reassigned incident shows the new assignee.</p></figcaption></figure>
 
-Once reassigned, the user will get an email notifying them about it. 
+The reassign option is available from:
 
-### What happens to escalations?
-
-Your escalation policy for the incident _will NOT be affected_. It will continue as is. 
-
-### Where do I reassign incident(s)?
-
-You will see the reassign incident option on every incident table. More particularly it can be found on -
-
-1. Dashboard
-2. Incident details page
-3. Incidents listed for a service
+- Dashboard
+- Incident details page
+- Incidents listed for a service
 
 {% hint style="danger" %}
-You cannot assign an incident to a team member with **Support role**
+You cannot reassign an incident to a team member with the **Support** role.
 {% endhint %}
+
+## Effect on escalations
+
+Reassigning an incident does not affect the escalation policy. The policy continues running as configured.

--- a/incidents/resolve-timer.md
+++ b/incidents/resolve-timer.md
@@ -1,112 +1,94 @@
 ---
-description: >-
-  Resolved by Timer resolves incidents after a specified time period.
+description: Resolve by Timer automatically resolves incidents after a set duration if they haven't been manually resolved.
 ---
 
-<figure><img src="../.gitbook/assets/resolve-timer/cover.png" alt=""><figcaption></figcaption></figure>
+# Resolve by Timer
 
-## Introduction
-**Resolved by Timer** lets you automatically resolve incidents after a fixed duration. Once an incident is triggered, a countdown starts. If the incident hasn’t been manually resolved by the time the countdown ends, Spike will mark it as Resolved with Timer.
+<figure><img src="../.gitbook/assets/resolve-timer/cover.png" alt="Resolve by Timer feature on Spike"><figcaption><p>Resolve by Timer on Spike.</p></figcaption></figure>
 
-You’ll see a badge on the incident row and incident page, along with a visual indicator showing the timer. You can cancel the timer at any point from the incident view.
+## What is Resolve by Timer?
 
-![The badge makes it clear how the incident was resolved](../.gitbook/assets/resolve-timer/resolve-badge.png)
+Resolve by Timer automatically resolves an incident after a set duration. When an incident triggers, a countdown starts. If the incident isn't resolved before the countdown ends, Spike marks it as **Resolved by Timer**. You can cancel the timer at any point from the incident view.
 
-Resolve Timer can be set up in multiple ways:
+You can set up Resolve by Timer in three ways:
 
-**Integration-level**: apply the same timer to all incidents from an integration.
-
-**Alert rules**: apply timers only when certain conditions are met (e.g., based on severity or service).
-
-**Playbooks**: apply timers as part of your playbook.
-
+- **Integration level**: applies to all incidents from an integration
+- **Alert rules**: applies only when certain conditions are met
+- **Playbooks**: applies as part of your response playbook
 
 {% hint style="success" %}
-Resolve Timer is available on **all plans**.
+Resolve by Timer is available on all plans.
 {% endhint %}
 
----
+## How it works
 
-## How it works?
+<figure><img src="../.gitbook/assets/resolve-timer/timer-different-states.png" alt="Timer in different states on an incident"><figcaption><p>The timer countdown visible on an incident.</p></figcaption></figure>
 
-![Timer in motion](../.gitbook/assets/resolve-timer/timer-different-states.png)
+When an incident triggers, a countdown begins automatically. The incident behaves normally during this time. It can be acknowledged, updated with notes, or manually resolved at any time.
 
-When an incident is triggered, a countdown begins automatically. This timer runs in the background while the incident behaves like any other — it can be acknowledged, updated with notes, or manually resolved at any time.
+If the countdown ends and the incident is still open, Spike marks it as **Resolved by Timer**. A badge and countdown indicator appear on the incident row and detail page.
 
-If the countdown finishes and the incident is still open, Spike marks it as Resolved with Timer. A badge and countdown indicator appear on the incident row and detail page, making it clear when and how the resolution happened.
+<figure><img src="../.gitbook/assets/resolve-timer/resolve-badge.png" alt="Badge showing incident was resolved by timer"><figcaption><p>The badge shows the incident was resolved by timer.</p></figcaption></figure>
 
----
+## How to set up Resolve by Timer on an integration
 
-## Setup Resolve timer on integration level
-Use this when you want every incident from a specific integration to resolve after a set time.
-
-{% stepper %}
-{% step %}
-When **Editing**/**Creating** your integration scroll to **Advanced Configuration** and locate the **Resolve Timer** toggle.
-{% endstep %}
-{% step %}
-Toggle **Resolve Timer** to **ON**, enter your time value, select the unit (**Minutes**, **Hours**, or **Days**), and click **Save**.
-{% endstep %}
-{% endstepper %}
-
-Example: Setting 24 hours will automatically resolve all incidents from this integration after 24 hours.
-
-![How to setup resolve timer with integration](../.gitbook/assets/resolve-timer/in-integration.png)
-
-## Setup Alert Rule-based Resolve timer
-Use this for granular control over which incidents to set a timer for.
+**Best for:** Applying the same timer to all incidents from a specific integration.
 
 {% stepper %}
 {% step %}
-While **Editing**/**Creating** an alert rule, set up your alert conditions to define which incidents should trigger this rule.
+When editing or creating your integration, scroll to **Advanced Configuration** and locate the **Resolve by Timer** toggle.
 {% endstep %}
 {% step %}
-In **Actions** select **Resolve After**. Enter the time value, select the unit, then **Save** or **Update** the rule.
+Toggle **Resolve by Timer** on, enter your time value, select the unit (**Minutes**, **Hours**, or **Days**), and click **Save**.
 {% endstep %}
 {% endstepper %}
 
-Example: Database incidents automatically resolve after 2 hours if not manually handled.
+<figure><img src="../.gitbook/assets/resolve-timer/in-integration.png" alt="Resolve by Timer setup in integration settings"><figcaption><p>Setting Resolve by Timer at the integration level.</p></figcaption></figure>
 
-![How to setup resolve timer with Alert rules](../.gitbook/assets/resolve-timer/in-alert-rules.png)
+## How to set up Resolve by Timer with alert rules
 
-## Setup Resolve timer in Playbooks
-Use this to set timer as part of your response playbook
+**Best for:** Applying timers only to incidents that meet specific conditions.
 
 {% stepper %}
 {% step %}
-While **editing** or **creating** a playbook, add an action to apply a Resolve Timer.  
+While editing or creating an alert rule, set up your conditions to define which incidents the rule applies to.
 {% endstep %}
 {% step %}
-You can choose when the timer should start — for example, immediately on trigger or when the incident status changes (e.g., to **Acknowledged**).  
+In **Actions**, select **Resolve by Timer**. Enter the time value and select the unit (**Minutes**, **Hours**, or **Days**), then save or update the rule.
 {% endstep %}
 {% endstepper %}
 
-![How to setup resolve timer with Playbooks](../.gitbook/assets/resolve-timer/in-playbooks.png)
+<figure><img src="../.gitbook/assets/resolve-timer/in-alert-rules.png" alt="Resolve by Timer setup in alert rules"><figcaption><p>Setting Resolve by Timer via alert rules.</p></figcaption></figure>
 
----
+## How to set up Resolve by Timer in playbooks
 
-## FAQ
+**Best for:** Including a timer in your incident response workflow.
 
-<details>
-<summary>Can I Remove Timer for specific incidents?</summary>
-Yes, You can remove it from the incident by clicking on the remove timer button.
-</details>
+{% stepper %}
+{% step %}
+While editing or creating a playbook, add an action to apply Resolve by Timer.
+{% endstep %}
+{% step %}
+Choose when the timer should start: immediately on trigger, or when the incident status changes to **Acknowledged**.
+{% endstep %}
+{% endstepper %}
 
-<details>
-<summary>Can I set different times for different severity levels?</summary>
-Yes, using alert rules you can create different configurations based on incident severity, service, or other conditions.
-</details>
+<figure><img src="../.gitbook/assets/resolve-timer/in-playbooks.png" alt="Resolve by Timer setup in playbooks"><figcaption><p>Setting Resolve by Timer via playbooks.</p></figcaption></figure>
 
-<details>
-<summary>What's the minimum resolution time?</summary>
-1 minute, though we recommend at least 15-30 minutes for most use cases.
-</details>
+## FAQs
 
-<details>
-<summary>Will I get notified when incidents resolve by timer?</summary>
-This depends on your notification settings. You can configure to get alerts on resolve incidents
-</details>
+### Can I remove the timer for a specific incident?
 
----
+Yes. Click the remove timer button on the incident to cancel it.
 
-*If you need help setting up Resolve Timer, reach out to [support@spike.sh](mailto:support@spike.sh).*
+### Can I set different times for different severity levels?
+
+Yes. Use alert rules to apply different timers based on incident severity.
+
+### What is the minimum resolution time?
+
+1 minute. For most use cases, 15 to 30 minutes is a more practical minimum.
+
+### Will I be notified when an incident resolves by timer?
+
+This depends on your notification settings. You can configure alerts for resolved incidents.

--- a/incidents/sharing-incidents.md
+++ b/incidents/sharing-incidents.md
@@ -1,29 +1,27 @@
 ---
-description: Share your incidents with the world, embed in your docs and more.
+description: Share any incident as a public link with customers, stakeholders, or your team.
 ---
 
 # Sharing incidents
 
-### Global settings to allow sharing
+You can share any incident as a public link. This is useful for communicating outages to customers or embedding status updates in your docs.
 
-To share incidents publicly,  you will first need to allow sharing of incidents for your entire organisation globally.&#x20;
+## Enable public sharing
 
-Head over to [Alerts under organisation settings](https://app.spike.sh/settings/general/alerts) and select your choice to enable or disable your team from sharing incidents publicly.
+Public sharing is off by default. To turn it on, go to [Alerts under organisation settings](https://app.spike.sh/settings/general/alerts) and enable it for your organisation.
 
-![Enable public sharing from organisation settings](<../.gitbook/assets/image (46).png>)
+<figure><img src="../.gitbook/assets/image (46).png" alt="Enable public sharing from organisation settings"><figcaption><p>Enable public sharing from organisation settings.</p></figcaption></figure>
 
 {% hint style="info" %}
-If public incidents are disabled in organisation settings then all public incident links will be private instantly.&#x20;
+If you disable public sharing in organisation settings, all existing public incident links become private immediately.
 {% endhint %}
 
-### Sharing a single incident
+## How to share an incident
 
-To share an incident, you will need to click on the **Share** button on the right-hand side of the incident details page.&#x20;
+Open an incident and click the **Share** button on the right-hand side of the incident details page.
 
-![Share as public page](<../.gitbook/assets/image (47).png>)
-
-The link for the public page will **not be unique** for each time to decide to share or not. However, the public page link is unique to each incident.
+<figure><img src="../.gitbook/assets/image (47).png" alt="Share an incident as a public link"><figcaption><p>Click Share on the incident details page to get a public link.</p></figcaption></figure>
 
 {% hint style="info" %}
-You will not see the share button if public incidents are disabled in organisation settings as mentioned in the above section
+Each incident has a unique public link. The link stays the same regardless of how many times you toggle sharing on or off.
 {% endhint %}

--- a/incidents/what-is-an-incident.md
+++ b/incidents/what-is-an-incident.md
@@ -1,44 +1,39 @@
 ---
-description: Learn the basics of an incident.
+description: An incident is any issue that needs to be investigated and resolved, often one that affects your customers.
 ---
 
 # What is an incident?
 
-Incident is any issue that needs to be worked upon and resolved. Many a times, these incidents often affects your customers. When we get an incident, we alert and assign the incident to the right person using escalation policy attached to that integration.
+An incident is any issue that needs to be investigated and resolved. When a connected monitoring tool detects a problem, Spike creates an incident and alerts the right person based on the [escalation policy](../escalations/introduction-to-escalations.md) attached to that integration.
 
 ## Examples
 
-1. Monitoring CPU utilization - alerts at high utilization at say, 80%
-2. Monitoring Memory consumption - alerts at high consumption at say, 90%
-3. DB monitoring alerts&#x20;
-4. DB backup fails
-5. Billing fails
-6. Sending notification fails
-7. Errors on loading dashboard
-8. Website down monitored with uptime monitoring
+Common examples of incidents include:
 
-_and many more ...._
+- CPU or memory utilization crossing a critical threshold
+- Database monitoring alerts
+- Database backup failures
+- Billing process failures
+- Notification delivery failures
+- Dashboard loading errors
+- Website downtime
 
 {% hint style="info" %}
-You can use a simple webhook integration and create incidents from your code too. [Know more here.](https://docs.spike.sh/integrations-guideline/integrating-with-webhooks)
+You can also create incidents directly from your code using a [webhook integration](../integrations-guideline/integrating-with-webhooks.md).
 {% endhint %}
 
-## Understanding incident statuses
+## Incident statuses
 
-Incidents can have one of the below statuses -&#x20;
-
-1. **Triggered**
-2. **Acknowledged**
-3. **Resolved**
+Every incident has one of three statuses. See [incident statuses](incident-statuses.md) for the full breakdown.
 
 ### Triggered
 
-When an incident is **triggered**, Spike loads the escalation policy attached to the integration and sends an alert. _We continue to send automated alerts based on the escalation policy until the incident is acknowledged_. Once the person has received the alert, they choose to acknowledge or resolve. We do not send alerts when incidents are acknowledged and resolved. In this state, repeat incidents are automatically suppressed and logged reducing alert fatigue.
+A triggered incident means Spike has detected a problem and is actively alerting. Spike works through the escalation policy, sending alerts until someone acknowledges or resolves the incident. Repeat incidents are automatically suppressed to reduce [alert fatigue](../alerts/personal-alerts-management/README.md).
 
 ### Acknowledged
 
-An **acknowledged** incident would mean that the work for the resolution of incident is ongoing. In this state, we **do not** send any alerts and stop the escalation policy to where it stands. You can customise the settings to have a timeout for amount of time the incident remains in acknowledged state and does not get resolved. Once this timeout reaches, we change the status to triggered and start sending alerts again. _The acknowledge timeout setting is optional._ In this state, repeat incidents are automatically suppressed and logged reducing alert fatigue
+An acknowledged incident means someone is working on a fix. Spike stops alerting and pauses the escalation policy. You can optionally set an [acknowledge timeout](acknowledge-timeout.md): a time limit after which Spike moves the incident back to triggered and resumes alerting if it hasn't been resolved.
 
 ### Resolved
 
-Once incident has been fixed, you can mark it as **resolved**. In this case, no alerts are sent and escalation policy resets in case if there is a new incident again.
+A resolved incident means the issue is fixed. Spike stops all alerts and resets the escalation policy for any future incidents on that integration.

--- a/incidents/why-does-message-parsing-fail.md
+++ b/incidents/why-does-message-parsing-fail.md
@@ -1,46 +1,27 @@
 ---
-description: >-
-  We parse the data integrations send in JSON to human readable format.
-  Sometimes it fails. What does it mean and why does it happen?
+description: Message parsing fails when Spike cannot convert an integration's JSON payload into a readable format.
 ---
 
 # Why does message parsing fail?
 
-## Message parsing failed
+When an integration triggers an incident, Spike parses the JSON payload into a readable format. Some integrations send payloads in formats the parser doesn't recognise, and that's when it fails.
 
-After you setup integrations on Spike.sh, these integrations send us payload of JSON data for every new incident. We convert this JSON data into a human-readable format which is then used on the [incidents table](https://app.spike.sh/incidents) and in phone calls, emails, Slack etc. 
+<figure><img src="../.gitbook/assets/image (40).png" alt="Example of incident message parsing fail"><figcaption><p>An incident with a failed message parse in the incidents table.</p></figcaption></figure>
 
-Sometimes, this parsing fails and your table might see an entry like below - 
+## Does it affect alerts?
 
-![Example of incident message parsing fail](<../.gitbook/assets/image (40).png>)
+Yes. Alerts still go out, but the incident message won't be included.
 
-### Report with a single click
+## Does it affect the incident?
 
-When you see this, please report this issue to us so we can start looking into this. The more you report the better this parsing gets.
+No. The incident is still created and all details are available. Click the incident ID to view the full details.
 
-![Report with a single click](../.gitbook/assets/spike-incident-parsing-fail-report.gif)
+## Report a parsing failure
 
-### Why does this happen?
+When you see a parsing failure, report it with a single click. Each report helps improve the parser for future incidents.
 
-We try our best to parse all the payloads and convert it into a gist you can actually read and get a sense of the incident. Each integration has tons of cases and our parser fails to understand it and that's what causes Incident message parsing fail. 
-
-### Does it affect my alerts?
-
-Yes, your alerts will not have the message. 
-
-### Would I still receive alerts?
-
-Yes. Alerts will still be sent however the exact incident message will not be available. 
-
-### Is the incident affected?
-
-No. The details of your incident are still available. You can click on the #ID of the incident and see all the details as you do with other incidents.
-
-### Should we take any action?
-
-We would love it if you can please report the incident. 
+<figure><img src="../.gitbook/assets/spike-incident-parsing-fail-report.gif" alt="Report a parsing failure with a single click"><figcaption><p>Report a parsing failure directly from the incidents table.</p></figcaption></figure>
 
 {% hint style="warning" %}
-Once the parser is fixed, it will not change the message for existing incidents but it will surely pave the way for future incidents
+Once the parser is fixed, existing incidents won't be updated. The fix applies to new incidents only.
 {% endhint %}
-

--- a/services/introduction-to-services-on-spike.md
+++ b/services/introduction-to-services-on-spike.md
@@ -1,17 +1,14 @@
 ---
-description: >-
-  Services are a way to scope your internal services from your architecture. Each of your service can have multiple integrations and you can create unlimited number of services.
+description: In Spike, every integration belongs to a service. Services are how you organize and track incidents by component.
 ---
 
-# Introduction to services on Spike
+# Services
 
-## **What is a service?**
-
-**You can think of services as a microservice.** Services are a way to scope your internal services from your architecture. Each of your service can have multiple integrations and you can create unlimited number of services. We highly encourage you to create different services for each of your different modules.
+A service represents a component of your architecture, like an API, a database, or a frontend app. Each service can have multiple integrations. Incidents are scoped to the service that triggered them. You can create unlimited services.
 
 ## Why create a service?
 
-We ask users to create services to easily scope and track incidents, monitor platform health better and visualise reports segregated by every service.
+Services help you scope and track incidents, monitor platform health, and view reports by component. Create a separate service for each module or part of your architecture.
 
 {% hint style="danger" %}
 Services are mandatory on Spike.
@@ -23,6 +20,6 @@ Services are mandatory on Spike.
 
 ## Affected services
 
-When an incident is triggered, a service gets affected. Many a times, other integrations also get affected adding up to more incidents. The **Affected services section** on the dashboard brings you transparency on which services needs to be worked upon.
+When an incident triggers, the associated service is marked as affected. A single root cause can impact multiple services at once, each triggering its own incidents. The **Affected services** section on the dashboard shows all impacted services so you can see the full scope of an outage at a glance.
 
-![Affected services on Spike](<../.gitbook/assets/Screenshot 2020-06-24 at 10.37.32 AM.png>)
+<figure><img src="../.gitbook/assets/Screenshot 2020-06-24 at 10.37.32 AM.png" alt="Affected services on the Spike dashboard"><figcaption><p>Affected services on the Spike dashboard.</p></figcaption></figure>

--- a/what-is-spike.md
+++ b/what-is-spike.md
@@ -1,65 +1,49 @@
 ---
-description: >-
-  Spike.sh is a simple incident management platform. We help you by alerting the right team members about incidents that affect your customer.
+description: Spike is an incident management platform that pages the right person when something breaks in your infrastructure.
 ---
+
 # What is Spike.sh?
 
-Spike.sh is a simple incident management platform. We help you by alerting the right team members about incidents that affect your customer.&#x20;
+Spike is an incident management platform. Connect your monitoring tools, define who gets paged and how, and Spike handles alerting when incidents fire.
 
-## Focusing on simplicity
+## How Spike works
 
-Spike.sh's mission is to reduce the complexity of managing incidents and make it simple so teams of all sizes use it.&#x20;
+Every incident starts with an integration. When a connected monitoring tool detects a problem, it sends a signal to Spike. Spike creates an incident and triggers your escalation policy, which determines who gets notified and through which channel. If no one responds in time, Spike moves to the next person in line. Once resolved, reports capture the data so your team can track patterns over time.
 
-**Our platform consists of a few modules -**
-
-1. Integrations
-2. Alerts
-3. Escalations
-4. Services
-5. On-call schedules
-6. Reports
-7. Automation
-    - Alert rules: automate routing alerts, setting priority and severity, triggering outbound webhooks
-    - Outbound webhooks: trigger your scripts by creating an outbound webhook (GET/POST/PUT requests)
-    - Title remapper: extract values from an incident and change the incident title programatically for better context
-    - Playbooks (beta): Automate common actions like creating war rooms or creating a ticket on JIRA, or updating your status page
-
-{% hint style="info" %}
-To get in depth, please reach out to us at [demo@spike.sh](mailto:demo@spike.sh) or book a call directly on our [calendar](https://calendly.com/spikehq).&#x20;
-{% endhint %}
+## Core modules
 
 ### Integrations
 
-{% content-ref url="integrations-guideline/setup-integrations.md" %}
-[setup-integrations.md](integrations-guideline/setup-integrations.md)
-{% endcontent-ref %}
-
-We integrate with a number of services and tools so you can use Spike as a central intelligence as we gather incidents and alert the right person. You can add an unlimited number of integrations, there are no restrictions. Each integration would have a separate identifiable token so you needn't worry about incidents mixing up and rest knowing that we have got you covered.
+Spike connects to [over 100 monitoring, logging, and observability tools](integrations-guideline/setup-integrations.md). Each integration gets a unique token, so incidents from different sources stay separate. You can add as many integrations as you need with no restrictions.
 
 {% hint style="info" %}
-We have a growing [list of integrations](https://spike.sh/integrations). If you don't see an integration you need then email us at [integrations@spike.sh](mailto:integrations@spike.sh) and we would be happy to build it for you and release it for everyone.
+Don't see an integration you need? Email [integrations@spike.sh](mailto:integrations@spike.sh) and we'll build it.
 {% endhint %}
 
 ### Services
 
-![Services on spike](<.gitbook/assets/affected services.png>)
+<figure><img src=".gitbook/assets/affected services.png" alt="Services on Spike"><figcaption><p>Services map to components in your infrastructure.</p></figcaption></figure>
 
-**You can think of services as a microservice.** Services are a way to scope your internal services from your architecture. Each of your service can have multiple integrations and you can create unlimited number of services. We highly encourage you to create different services for each of your different modules.
-
-You can create services by just adding a name to it. No other field is required. With the power of unlimited services, you can create a blueprint of your entire architecture on Spike. This way, we will tell which service is affected and what is the current health status in terms of open incidents.
+Services map to components in your infrastructure: a backend API, a payment service, a worker queue. Each service holds multiple integrations. When an incident fires, Spike shows which service is affected and its current health status based on open incidents. You can create as many services as you need to reflect your full architecture.
 
 ### Escalations
 
-![Multiple escalation policies](.gitbook/assets/escalations-list.png)
+<figure><img src=".gitbook/assets/escalations-list.png" alt="Escalation policies on Spike"><figcaption><p>Create separate escalation policies for teams, services, or situations.</p></figcaption></figure>
 
-We provide simplicity by un-complicating escalation policies by allowing you to choose your alert channels. Anyone from your team can create escalation policies you can easily use. With the power of unlimited escalations, you can create escalations policies just for your self or one for your team and one for every team in your organization.
+An [escalation policy](escalations/introduction-to-escalations.md) defines who gets paged and in what order. You can build separate policies for different teams or services. If the first person doesn't acknowledge in time, Spike moves down the policy until someone responds.
 
-### Reports
+### Alerts
 
-![](<.gitbook/assets/Screenshot 2020-06-24 at 10.38.57 AM.png>)
+Spike reaches your team through phone calls, SMS, email, Slack, Microsoft Teams, WhatsApp, Telegram, Discord, and Pushover. Each person sets their own alert preferences. [Alert rules](alerts/alert-rules.md) let you route, filter, and prioritize alerts automatically based on incident properties.
 
-![Reports and data you will actually use](<.gitbook/assets/image (18).png>)
+### On-call schedules
 
-No matter the size of your team, we believe everyone should have access to reports to bring in transparency to know how your platform measures in terms of open incidents. **We provide graphs to get a sense of total incidents, new incidents and repeated incidents for a given time period.**
+[On-call schedules](oncall-schedules/introduction-to-on-call-schedules.md) control who is on-call at any given time. Build schedules with layers and slots, set up overrides for coverage gaps, and sync shifts to Google Calendar, Apple Calendar, or Outlook.
 
-__
+### Playbooks
+
+[Playbooks](playbooks/introduction-to-playbooks.md) automate the repetitive work that happens when an incident fires. Create a war room, open a Jira ticket, update your status page. Playbooks run these steps automatically so your team can focus on the fix.
+
+{% hint style="info" %}
+To see Spike in action, book a call at [calendly.com/spikehq](https://calendly.com/spikehq) or email [demo@spike.sh](mailto:demo@spike.sh).
+{% endhint %}


### PR DESCRIPTION
## Summary

- Rewrote description; removed "super simple and intuitive" and "Spike.sh"
- Removed filler opener ("Here's how to create...")
- Converted bold Step 1/Step 2 structure to {% stepper %} blocks
- Removed empty hint block
- Fixed "Make sure to" filler phrasing
- Removed "we highly recommend" (first-person plural)
- Fixed "vs" → clearer prose
- Replaced all `![]()` image syntax with `<figure>` tags
- Removed em dashes throughout
- Removed `&#x20;` trailing whitespace artifact

## Test plan

- [ ] Page renders correctly on GitBook preview
- [ ] Stepper blocks render with all three steps
- [ ] All four figures load
- [ ] Link to Escalations section resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)