### PR TITLE
docs: revamp on-call overrides

### DIFF
--- a/oncall-schedules/override-an-on-call.md
+++ b/oncall-schedules/override-an-on-call.md
@@ -1,67 +1,50 @@
 ---
-description: >-
-  On-call overrides allow you to assign temporary coverage for shifts without altering your entire schedule
+description: On-call overrides assign temporary coverage for a shift without changing the underlying schedule.
 ---
 
 # On-call overrides
 
-<figure><img src="../.gitbook/assets/oncall/override-cover.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/override-cover.png" alt="On-call overrides on Spike"><figcaption></figcaption></figure>
 
-## Introduction
-On-call overrides give your team flexibility by allowing temporary adjustments to your schedule without permanently changing it. Whether you're stepping out for a dentist appointment or taking a well-deserved break after a hectic week, overrides help ensure that incident coverage continues seamlessly. Overrides are non-recurring and ideal for short-term coverage.
-
-{% hint style="success" %}
-Overrides are temporary and do not repeat like regular schedules, simplifying one-time changes to your on-call coverage.
-{% endhint %}
+Overrides are one-time, non-recurring adjustments. Use them when someone needs short-term coverage without altering the schedule itself.
 
 ## Adding an override
 
-You can create overrides for a specific user's shift or for the entire duration between a start and end time. Here’s how to set it up:
+From your [on-call schedule](https://app.spike.sh/on-calls), press `O` or click **Override**. Add the team member's name, start and end time, and an optional comment for context. Save to apply.
 
-{% tabs %}
-{% tab title="Set up instructions" %}
-* From your [on-call schedule](https://app.spike.sh/on-calls), press `O` or click on `Override`.
-* Add the name of the team member, the start and end time, and an optional comment for context.
-* **Save**: The override will be applied, and the selected member will temporarily take over on-call responsibilities.
-{% endtab %}
-{% endtabs %}
-
+There are two ways to use overrides:
 
 {% tabs %}
 {% tab title="Cover a user's shift" %}
-Example: In the screenshot below, James has been assigned an override to cover Kaushik's shifts from January 14th to January 16th at midnight. The comment provides clarity about the reason for the override.
+The override replaces a specific member's on-call time. In the example below, James covers Kaushik's shifts from January 14th to January 16th at midnight.
 
-<figure><img src="../.gitbook/assets/oncall/cover-users-shift.png" alt=""><figcaption></figcaption></figure>
-<figure><img src="../.gitbook/assets/oncall/james-cover-kaushik.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/cover-users-shift.png" alt="Override covering a specific user's shift"><figcaption></figcaption></figure>
+
+<figure><img src="../.gitbook/assets/oncall/james-cover-kaushik.png" alt="James covering Kaushik's on-call shift"><figcaption></figcaption></figure>
 {% endtab %}
 {% tab title="Cover everyone's shift" %}
-Example: In the screenshot below, James has been assigned an override to cover **everyone's** shifts from January 14th to January 16th at midnight. The comment provides clarity about the reason for the override.
+The override takes over all on-call responsibilities for the selected time window. In the example below, James covers everyone's shifts from January 14th to January 16th at midnight.
 
-<figure><img src="../.gitbook/assets/oncall/cover-everyone-shift.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/cover-everyone-shift.png" alt="Override covering everyone's shifts"><figcaption></figcaption></figure>
 
-
-<figure><img src="../.gitbook/assets/oncall/james-cover-everyone.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/james-cover-everyone.png" alt="James covering all on-call shifts"><figcaption></figcaption></figure>
 {% endtab %}
 {% endtabs %}
 
-
 ## FAQs
-<details>
-<summary>Can I add multiple overrides for the same time period?</summary>
-Yes, you can. If overrides overlap, the most recently added override will take precedence.
-</details>
 
-<details>
-<summary>Can I override the schedule for multiple team members at once?</summary>
-No, each override is specific to one user and covers their shift or a time period. Multiple overrides must be added individually.
-</details>
+### Can I add multiple overrides for the same time period?
 
-<details>
-<summary>Are notifications sent when an override is added or removed?</summary>
-Yes, team members affected by the override will receive notifications about the change.
-</details>
+Yes. If overrides overlap, the most recently added override takes precedence.
 
-<details>
-<summary>Who can add or remove overrides?</summary> 
-Anyone who is not assigned a "Viewer" role in your team can add and delete overrides. This permission is fixed and cannot be customized. 
-</details>
+### Can I override the schedule for multiple team members at once?
+
+No. Each override covers one user. Add separate overrides for each member you want to cover.
+
+### Are notifications sent when an override is added or removed?
+
+Yes. Team members involved in the override receive notifications about the change.
+
+### Who can add or remove overrides?
+
+Anyone without a Viewer role can add and delete overrides. This permission is fixed and cannot be customized.


### PR DESCRIPTION
## Summary
- Rewrote description: removed "let you" phrasing
- Removed redundant `## Introduction` header
- Trimmed opener: cut marketing fluff, kept the key facts
- Removed redundant hint block
- Removed single-tab wrapper around setup steps, kept content as plain prose
- Kept two-tab block for "Cover a user's shift" / "Cover everyone's shift"
- Added alt text to all images
- Converted FAQs from `<details>` to `## FAQs` + `###` headers
- Fixed notification FAQ wording: "involved in the override" instead of "affected"

## Test plan
- [ ] Preview renders correctly in GitBook
- [ ] Both tabs display with images
- [ ] FAQ headers render as proper H3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)