### PR TITLE
docs: revamp notifications for on-call shifts

### DIFF
--- a/oncall-schedules/notifications-for-on-call-shifts.md
+++ b/oncall-schedules/notifications-for-on-call-shifts.md
@@ -1,77 +1,56 @@
 ---
-description: >-
-  Get notifications via phone call, WhatsApp, Telegram, SMS, Email, Slack, Microsoft Teams, and Discord when your on-call shift starts and ends.
----
-<figure><img src="../.gitbook/assets/oncall/oncall-notifications--cover.png" alt="On-call shift rotations alerts on Spike"><figcaption></figcaption></figure>
-
-# Notifications for On-Call Shifts
-
-Stay updated on your on-call shifts with notifications across multiple channels. Spike supports both **personal** and **team-wide** notifications for on-call schedules.
-
-## Available Notification Channels
-
-### **Personal Notifications**
-Receive direct alerts when your on-call shift starts or ends:
-- Phone calls
-- SMS
-- WhatsApp
-- Telegram
-- Email
-
-### **Team-wide Alerts**
-Notify your team when any member starts or ends their shift:
-- Slack
-- Microsoft Teams
-- Discord
-- Webhooks
-
+description: Spike sends notifications when your on-call shift starts or ends, across personal and team-wide channels.
 ---
 
-## When Your On-Call Shift Starts/Ends
+<figure><img src="../.gitbook/assets/oncall/oncall-notifications--cover.png" alt="On-call shift notifications on Spike"><figcaption></figcaption></figure>
 
-![Personal On-call notifications](<../.gitbook/assets/oncall/oncall-notifications--personal--shift-start-notifications.png>)
+# Notifications for on-call shifts
 
-You can choose to receive alerts over **Phone calls, WhatsApp, Telegram, SMS, and Email** when your shift starts or ends. 
+Spike notifies you when your on-call shift starts or ends. Personal notifications go directly to you. Team notifications go to shared channels like Slack, Teams, and Discord.
 
-To enable notifications:
-1. Visit [On-call notifications in settings](https://app.spike.sh/settings/personal-on-call).
-2. Enable alerts separately for **Shift Start** and **Shift End**.
-3. Once saved, notifications will apply to all on-call schedules you are part of.
+## Personal notifications
 
-{% hint style="info" %}
-You can override these per schedule. Visit **On-call > Settings > My alerts**
-{% endhint %}
+<figure><img src="../.gitbook/assets/oncall/oncall-notifications--personal--shift-start-notifications.png" alt="Personal on-call shift notification settings"><figcaption><p>Personal notification settings for shift start and end.</p></figcaption></figure>
 
----
-
-## When Any Team Member Starts/Ends Their On-Call Shift
-
-![Slack notifications for shift start and ends](<../.gitbook/assets/oncall/oncall-notifications--team--slack.png>)
-
-You can set up notifications when **anyone** in your team starts or ends an on-call shift. 
+Spike sends personal notifications via phone call, SMS, WhatsApp, Telegram, and Email when your shift starts or ends.
 
 To enable:
-1. Visit [Slack settings under Organisation > Alerts](https://app.spike.sh/settings/general/alerts).
-2. Select one or more channels where notifications should be sent.
-3. Once saved, all members in the selected Slack channels will receive updates on shift start and end.
 
-Similar settings are available for **Microsoft Teams** and **Discord**.
+1. Visit [On-call notifications in settings](https://app.spike.sh/settings/personal-on-call).
+2. Enable notifications separately for **Shift Start** and **Shift End**.
+3. Once saved, the settings apply to all on-call schedules you are part of.
 
 {% hint style="info" %}
-You can override Slack and Microsoft Teams alerts for per on-call schedule under the schedule's settings.
+You can override these per schedule. Visit **On-call > Settings > My alerts**.
 {% endhint %}
 
----
+## Team notifications
 
-## Webhook trigger on On-call shift rotations
+<figure><img src="../.gitbook/assets/oncall/oncall-notifications--team--slack.png" alt="Slack notifications for on-call shift start and end"><figcaption><p>Slack notifications when any team member's shift starts or ends.</p></figcaption></figure>
 
-![Webhook triggers shift start and ends](<../.gitbook/assets/oncall/oncall-notifications--webhook.png>)
+Spike notifies a shared channel when any team member starts or ends their shift. This works with Slack, Microsoft Teams, and Discord.
 
-You can configure outbound webhooks to trigger using POST, PUT, or GET requests. Spike will send a webhook each time an on-call shift starts or ends, with separate requests for each event.
+To enable:
 
-If one shift ends and another begins immediately, Spike will trigger both the end and start webhooks in quick succession—each with its own payload.
+1. Visit [Slack settings under Organisation > Alerts](https://app.spike.sh/settings/general/alerts).
+2. Select one or more channels to receive notifications.
+3. Once saved, all members in the selected channels receive shift start and end updates.
 
-The webhook payload includes detailed information about the on-call schedule and the shift member. Refer below:
+Similar settings are available for Microsoft Teams and Discord.
+
+{% hint style="info" %}
+Slack and Microsoft Teams notifications can be overridden per schedule under the schedule's settings.
+{% endhint %}
+
+## Webhook trigger on shift rotations
+
+<figure><img src="../.gitbook/assets/oncall/oncall-notifications--webhook.png" alt="Webhook triggers for on-call shift start and end"><figcaption><p>Webhook payloads for shift start and end events.</p></figcaption></figure>
+
+Configure outbound webhooks to trigger on shift rotations using POST, PUT, or GET requests. Spike sends a webhook each time a shift starts or ends, with a separate request for each event.
+
+If one shift ends and another begins immediately, Spike triggers both the end and start webhooks in quick succession. Each has its own payload.
+
+The webhook payload includes details about the on-call schedule and the shift member.
 
 {% tabs %}
 {% tab title="Shift starts payload" %}
@@ -131,22 +110,20 @@ The webhook payload includes detailed information about the on-call schedule and
 {% endtab %}
 {% endtabs %}
 
----
-
 ## FAQs
-<details> 
-<summary>Can I receive on-call shift notifications via multiple channels?</summary> 
-Yes, you can enable multiple channels such as Phone calls, SMS, WhatsApp, Telegram, and Email for personal notifications. Team-wide notifications can be sent to Slack, Microsoft Teams, and Discord.
-</details> 
-<details>
-<summary>Are on-call notifications available on all plans?</summary> 
-Yes, on-call notifications are available on all plans. 
-</details>
-<details>
-<summary>Can I disable notifications for a specific on-call schedule?</summary>
-No, notifications apply to all on-call schedules globally. If you wish to disable them, you will need to turn off on-call notifications in your personal settings → https://app.spike.sh/settings/personal-on-call.
-</details>
-<details>
-<summary>Do on-call notifications count toward my monthly alert quota?</summary>  
-Yes, for plans with limited alerts per month, on-call shift notifications are included in your monthly quota.  
-</details>
+
+### Can I receive on-call shift notifications via multiple channels?
+
+Yes. You can enable phone calls, SMS, WhatsApp, Telegram, and Email for personal notifications. Team notifications can go to Slack, Microsoft Teams, and Discord simultaneously.
+
+### Are on-call notifications available on all plans?
+
+Yes, on-call notifications are available on all plans.
+
+### Can I disable notifications for a specific on-call schedule?
+
+Yes. Visit **On-call > Settings > My alerts** to override notification settings per schedule.
+
+### Do on-call notifications count toward my monthly alert quota?
+
+Yes. For plans with a monthly alert limit, on-call shift notifications count toward that quota.

--- a/oncall-schedules/override-an-on-call.md
+++ b/oncall-schedules/override-an-on-call.md
@@ -1,67 +1,50 @@
 ---
-description: >-
-  On-call overrides allow you to assign temporary coverage for shifts without altering your entire schedule
+description: On-call overrides assign temporary coverage for a shift without changing the underlying schedule.
 ---
 
 # On-call overrides
 
-<figure><img src="../.gitbook/assets/oncall/override-cover.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/override-cover.png" alt="On-call overrides on Spike"><figcaption></figcaption></figure>
 
-## Introduction
-On-call overrides give your team flexibility by allowing temporary adjustments to your schedule without permanently changing it. Whether you're stepping out for a dentist appointment or taking a well-deserved break after a hectic week, overrides help ensure that incident coverage continues seamlessly. Overrides are non-recurring and ideal for short-term coverage.
-
-{% hint style="success" %}
-Overrides are temporary and do not repeat like regular schedules, simplifying one-time changes to your on-call coverage.
-{% endhint %}
+Overrides are one-time, non-recurring adjustments. Use them when someone needs short-term coverage without altering the schedule itself.
 
 ## Adding an override
 
-You can create overrides for a specific user's shift or for the entire duration between a start and end time. Here’s how to set it up:
+From your [on-call schedule](https://app.spike.sh/on-calls), press `O` or click **Override**. Add the team member's name, start and end time, and an optional comment for context. Save to apply.
 
-{% tabs %}
-{% tab title="Set up instructions" %}
-* From your [on-call schedule](https://app.spike.sh/on-calls), press `O` or click on `Override`.
-* Add the name of the team member, the start and end time, and an optional comment for context.
-* **Save**: The override will be applied, and the selected member will temporarily take over on-call responsibilities.
-{% endtab %}
-{% endtabs %}
-
+There are two ways to use overrides:
 
 {% tabs %}
 {% tab title="Cover a user's shift" %}
-Example: In the screenshot below, James has been assigned an override to cover Kaushik's shifts from January 14th to January 16th at midnight. The comment provides clarity about the reason for the override.
+The override replaces a specific member's on-call time. In the example below, James covers Kaushik's shifts from January 14th to January 16th at midnight.
 
-<figure><img src="../.gitbook/assets/oncall/cover-users-shift.png" alt=""><figcaption></figcaption></figure>
-<figure><img src="../.gitbook/assets/oncall/james-cover-kaushik.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/cover-users-shift.png" alt="Override covering a specific user's shift"><figcaption></figcaption></figure>
+
+<figure><img src="../.gitbook/assets/oncall/james-cover-kaushik.png" alt="James covering Kaushik's on-call shift"><figcaption></figcaption></figure>
 {% endtab %}
 {% tab title="Cover everyone's shift" %}
-Example: In the screenshot below, James has been assigned an override to cover **everyone's** shifts from January 14th to January 16th at midnight. The comment provides clarity about the reason for the override.
+The override takes over all on-call responsibilities for the selected time window. In the example below, James covers everyone's shifts from January 14th to January 16th at midnight.
 
-<figure><img src="../.gitbook/assets/oncall/cover-everyone-shift.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/cover-everyone-shift.png" alt="Override covering everyone's shifts"><figcaption></figcaption></figure>
 
-
-<figure><img src="../.gitbook/assets/oncall/james-cover-everyone.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/james-cover-everyone.png" alt="James covering all on-call shifts"><figcaption></figcaption></figure>
 {% endtab %}
 {% endtabs %}
 
-
 ## FAQs
-<details>
-<summary>Can I add multiple overrides for the same time period?</summary>
-Yes, you can. If overrides overlap, the most recently added override will take precedence.
-</details>
 
-<details>
-<summary>Can I override the schedule for multiple team members at once?</summary>
-No, each override is specific to one user and covers their shift or a time period. Multiple overrides must be added individually.
-</details>
+### Can I add multiple overrides for the same time period?
 
-<details>
-<summary>Are notifications sent when an override is added or removed?</summary>
-Yes, team members affected by the override will receive notifications about the change.
-</details>
+Yes. If overrides overlap, the most recently added override takes precedence.
 
-<details>
-<summary>Who can add or remove overrides?</summary> 
-Anyone who is not assigned a "Viewer" role in your team can add and delete overrides. This permission is fixed and cannot be customized. 
-</details>
+### Can I override the schedule for multiple team members at once?
+
+No. Each override covers one user. Add separate overrides for each member you want to cover.
+
+### Are notifications sent when an override is added or removed?
+
+Yes. Team members involved in the override receive notifications about the change.
+
+### Who can add or remove overrides?
+
+Anyone without a Viewer role can add and delete overrides. This permission is fixed and cannot be customized.


### PR DESCRIPTION
## Summary
- Rewrote description to one clear sentence
- Cleaned up opener: removed "Stay updated" filler
- Removed redundant `## Available Notification Channels` preview section
- Renamed sections to `## Personal notifications` and `## Team notifications`
- Fixed all images from `![]()` to `<figure>` tags with alt text and captions
- Removed `---` horizontal dividers throughout
- Fixed em dash in webhook section: split into two sentences
- Fixed hint block grammar for team notifications
- Corrected FAQ contradiction: "Can I disable for a specific schedule?" now correctly answers Yes
- Converted FAQs from `<details>` to `## FAQs` + `###` headers

## Test plan
- [ ] Preview renders correctly in GitBook
- [ ] Both payload tabs display correctly
- [ ] Images render with captions
- [ ] FAQ headers render as proper H3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)