### PR TITLE
docs: revamp change on-call rotation day

### DIFF
--- a/oncall-schedules/change-on-call-rotation-day.md
+++ b/oncall-schedules/change-on-call-rotation-day.md
@@ -1,35 +1,39 @@
 ---
-description: >-
-  You can change the shift rotation day for your on-call. Here's how.
+description: Change the rotation day on a weekly on-call schedule without losing coverage or disrupting the rotation order.
 ---
 
 # Change on-call rotation day
-Suppor you have an on-call on weekly shift which rotates every Wednesday and wish to change it to rotate from Monday (or any other day) then please read carefully. 
 
-It comes with 2 caveats though and this documents how to solve them. Please read carefully before changing.
+Say you have a weekly on-call schedule rotating every Wednesday and want to switch it to Monday. This page covers how to make that change and how to handle the two issues that come with it.
 
-## Example on-call
-Assume we have a Primary on-call schedule with A, B, C, and D as on-call members in the exact sequence rotating their duties on a weekly basis. C is currently on-call. Next week, D will be on-call.
+## How to change the rotation day
 
-### How to change?
-You must use the `schedule to start` option. This helps you to schedule an on-call to start a future date. The strategy here is to change the existing schedule to start on the next Monday (or the day you wish to start). To change, Visit on-call schedule > Settings > Schedule to start later next monday and submit.
+Use the **Schedule to start** option. This reschedules the on-call to begin on a new date without changing the members or rotation type.
 
-{% hint style="warning" %}
-**Caveats!** Be wary of this. There are 2 caveats since our systems will pretty much treat this as a new on-call schedule.
-1. No-one will be on-call till the next Monday. To solve this problem, we would recommend you add an override to cover the gap till then. 
-2. This will also change the on-call order. Before updating, C was currently on-call and D was supposed to go on-call next week. But now, we will have nobody on-call and A will be on-call again starting Monday. This resets the cycle.
-{% endhint %}
+Visit **On-call schedule > Settings > Schedule to start**, set the next Monday (or whichever day you want), and save.
 
-To combat the above caveats, we recommend the following actions
-1. Add C as an override till the next Monday.
-2. Change the order of members going on-call to D,A,B,C. To do this, visit on-call schedule > edit > scroll to the layer and rearrage the order by holding the `::` dots icon next to the names. 
+## What changes when you do this
 
-This would change the rotations from Monday to Monday.
+The system treats the updated schedule as a fresh start. Two things happen as a result:
 
-# F.A.Qs
+1. **Coverage gap.** No one is on-call from now until the new start date.
+2. **Rotation order resets.** The cycle restarts from the first member. For example, if A, B, C, D are in order and C is currently on-call with D due next, after the change A goes on-call first from Monday. D's turn gets pushed back.
 
-## Can this be undone?
-No, this operation cannot be undone. To test, feel free to create a new on-call schedule. You can archive it later.
+## Fixing the gap and order
 
-## Can I schedule to start in the past?
-No, we don't support scheduling an on-call to start in the past.
+To address both issues before making the change:
+
+1. Add C as an [override](override-an-on-call.md) to cover the gap until the new start date.
+2. Update the member order to D, A, B, C. Visit **On-call schedule > Edit**, scroll to the layer, and drag names using the `::` handle to reorder them.
+
+This keeps coverage continuous and picks up the rotation where it left off.
+
+## FAQs
+
+### Can this be undone?
+
+No. To test changes safely, create a separate on-call schedule first and archive it afterward.
+
+### Can I schedule to start in the past?
+
+No. The schedule to start option only supports future dates.


### PR DESCRIPTION
## Summary
- Rewrote description: one factual sentence covering what the page does
- Fixed opener typo ("Suppor") and removed duplicate "please read carefully"
- Restructured into four clear sections: how to change, what changes, how to fix
- Removed first-person from caveat block: "our systems," "we would recommend," "we will have"
- Replaced "To combat" with plain language
- Fixed `# F.A.Qs` (H1) → `## FAQs` with `###` sub-headers
- Removed first-person from FAQ answers
- Added internal link to override page

## Test plan
- [ ] Preview renders correctly in GitBook
- [ ] Override link resolves correctly
- [ ] FAQ headers render as proper H3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)