### PR TITLE
docs: revamp calendar sync for on-call overview

### DIFF
--- a/oncall-schedules/calendar-sync-for-oncall/README.md
+++ b/oncall-schedules/calendar-sync-for-oncall/README.md
@@ -1,15 +1,10 @@
 ---
-description: >-
-  Add your on-call schedule to your personal calendars like Google Calendar, Apple, and more.
+description: Sync your on-call schedule to Google Calendar, Apple Calendar, Outlook, or any calendar app that supports subscriptions.
 ---
 
-<!-- <figure><img src="../../.gitbook/assets/oncall/export-oncall-calendar--cover.png" alt="Export on-call schedule to your calendar"><figcaption></figcaption></figure> -->
+# Add on-call schedule to your calendar
 
-# Add On-call schedule to your calendar
-
-Keep track of your on-call shifts from your favorite calendar app. Spike provides a live subscription link that you can add to Google Calendar, Apple Calendar, Outlook, or any other calendar service that supports calendar subscriptions.
-
-Each link automatically updates whenever your schedule changes, so you always see the latest shifts without downloading any files.
+Spike generates a subscription link for your on-call schedule. Add it to Google Calendar, Apple Calendar, Outlook, or any app that supports calendar subscriptions. The link updates automatically when your schedule changes.
 
 <table data-card-size="large"data-view="cards">
   <thead>
@@ -42,68 +37,50 @@ Each link automatically updates whenever your schedule changes, so you always se
   </tbody>
 </table>
 
----
-
 ## Calendar link options
 
-You can choose what you want to sync:
+You can choose what to sync:
 
-- **All my shifts across all on-call schedules** – View every upcoming shift you are responsible for, regardless of schedule.
-
-- **My shifts for one on-call schedule**
-
-- **All team members’ shifts in one on-call schedule** – See who is on-call and who will be on-call at any time from your calendar.
----
+- **All my shifts across all on-call schedules**: every upcoming shift you are responsible for, regardless of schedule.
+- **My shifts for one on-call schedule**: your upcoming shifts in a specific schedule, useful when you're part of multiple schedules.
+- **All team members' shifts in one on-call schedule**: see who is on-call and who will be on-call at any time from your calendar.
 
 ## How calendar sync works
 
-The calendar link you copy is a Webcal (iCalendar) feed, which many calendar apps can read and update automatically. When your calendar app fetches the feed, Spike provides the latest on-call data for the next six months.
+The subscription link is a Webcal (iCalendar) feed. When your calendar app fetches the feed, Spike provides on-call data for the next six months.
 
-If you make changes to the schedule in Spike, they’ll appear in your calendar the next time your app refreshes the feed. The update interval depends on your calendar app and can vary by provider.
+If you make changes to the schedule in Spike, they'll appear in your calendar the next time your app refreshes the feed. The update interval depends on your calendar app and can vary by provider.
 
-To export your on-call schedule:
+To set up calendar sync:
 
-1. **Go to your on-call schedule settings** OR **[calendar view of on-calls](https://app.spike.sh/on-calls/calendar)**
-2. Click on **Calendar sync**
-3. Copy the subscription link or click it directly if your browser offers to open it in your calendar app.
+1. Go to your on-call schedule settings or the [calendar view of on-calls](https://app.spike.sh/on-calls/calendar).
+2. Click **Calendar sync**.
+3. Copy the subscription link, or click it directly if your browser offers to open it in your calendar app.
 
-![Export on-call calendar](<../../.gitbook/assets/oncall/export-oncall-calendar.png>)
+<figure><img src="../../.gitbook/assets/oncall/export-oncall-calendar.png" alt="Copying the on-call calendar subscription link from Spike"><figcaption><p>Copy the subscription link from your on-call schedule settings.</p></figcaption></figure>
 
+## Works with any calendar
 
----
-
-#### Works with Any Calendar
-
-<!-- <table data-view="cards"><thead><tr><th></th><th></th><th></th><th data-hidden data-card-cover data-type="files"></th><th data-hidden data-card-target data-type="content-ref"></th></tr></thead><tbody><tr><td>Linear</td><td>Connect with Linear to create issues about incidents</td><td></td><td><a href="../../.gitbook/assets/oncall/calendar-sync/Google Calendar tile.png">Google Calendar tile.png</a></td><td><a href="google-calendar-sync.md">google-calendar-sync.md</a></td></tr><tr><td>Google Calendar</td><td></td><td><a href="../../.gitbook/assets/oncall/calendar-sync/Apple Calendar tile.png">Apple Calendar tile.png</a></td><td><a href="apple-calendar-sync.md">apple-calendar-sync.md</a></td></tr><tr><td>Apple Calendar</td><td></td><td><a href="../../.gitbook/assets/oncall/calendar-sync/Outlook Calendar tile.png">Outlook Calendar tile.png</a></td><td><a href="microsoft-outlook-sync.md">microsoft-outlook-sync.md</a></td></tr></tbody></table> -->
-
-The Spike on-call calendar link follows the iCalendar (Webcal) standard.
-You can use it with any calendar app that supports subscriptions — including Notion, Proton Calendar, Zoho Calendar, or your preferred calendar tool.
-
----
+The subscription link follows the iCalendar (Webcal) standard. It works with any calendar app that supports subscriptions, including Notion, Proton Calendar, Zoho Calendar, or your preferred calendar tool.
 
 ## FAQs
 
-<details>
-<summary><strong>How often does my calendar update?</strong></summary>
+### How often does my calendar update?
+
 Your calendar app decides how often it refreshes the subscription. Spike always serves the latest data when requested.
-</details>
 
-<details>
-<summary><strong>Can I share my calendar link with others?</strong></summary>
-Yes but remember that sharing it will expose your schedule.
-</details>
+### Can I share my calendar link with others?
 
-<details>
-<summary><strong>Does the calendar show past shifts?</strong></summary>
+Yes, but sharing it will expose your schedule to whoever has the link.
+
+### Does the calendar show past shifts?
+
 No. The feed only includes upcoming shifts for the next six months.
-</details>
 
-<details>
-<summary><strong>What happens if my schedule changes?</strong></summary>
-Your subscribed calendar will update automatically the next time it refreshes the feed.
-</details>
+### What happens if my schedule changes?
 
-<details>
-<summary><strong>Can I unsubscribe later?</strong></summary>
-Yes. You can remove the subscribed calendar anytime from your calendar app’s settings.
-</details>
+Your subscribed calendar will update the next time your app refreshes the feed.
+
+### Can I unsubscribe later?
+
+Yes. Remove the subscribed calendar anytime from your calendar app's settings.


### PR DESCRIPTION
## Summary
- Rewrote description: plain language, names the supported apps
- Cleaned up opener: three direct sentences
- Fixed all three Calendar link options bullets to have consistent descriptions
- Removed commented-out cover image and commented-out table block
- Removed `---` horizontal dividers
- Fixed `#### Works with Any Calendar` → `## Works with any calendar`
- Fixed image from `![]()` to `<figure>` tag with alt text and caption
- Converted FAQs from `<details>` to `## FAQs` + `###` headers

## Test plan
- [ ] Cards table renders correctly in GitBook
- [ ] Image renders with caption
- [ ] FAQ headers render as proper H3s
- [ ] All three card links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)