### PR TITLE
docs: revamp linked calendars

### DIFF
--- a/oncall-schedules/linked-calendars.md
+++ b/oncall-schedules/linked-calendars.md
@@ -1,71 +1,38 @@
 ---
-description: >-
-  Integrate Spike with MongoDB Atlas to receive real-time alerts via Phone calls, SMS, Slack, MS Teams, and more for when your database triggers alerts or events.
+description: Add external or holiday calendars as overlays on your on-call schedule to plan shifts around holidays and team events.
 ---
 
-<figure><img src="../.gitbook/assets/oncall/linked-calendars/cover.png" alt="linked calendars"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/linked-calendars/cover.png" alt="Linked calendars on Spike"><figcaption></figcaption></figure>
 
-# Introduction
+# Linked calendars
 
-[Linked Calendars](https://app.spike.sh/oncalls/linked-calendars) let you bring in your team’s external or holiday calendars to view them alongside your on-call schedules. These calendars appear as overlays on the calendar view, helping you plan shifts around holidays, regional events, or company-wide leaves.
+Linked calendars display external or holiday calendars as overlays on your on-call schedule. Use them to plan shifts around holidays, regional events, or company-wide leaves. They do not modify or affect any existing on-call shifts.
 
-Linked calendars are for reference only. They **do not** modify, offset, or affect any existing on-call shifts.
+<figure><img src="../.gitbook/assets/oncall/linked-calendars/christmas-example.png" alt="Holiday calendar overlaid on an on-call schedule"><figcaption><p>A holiday calendar overlaid on the on-call schedule.</p></figcaption></figure>
 
-<figure><img src="../.gitbook/assets/oncall/linked-calendars/christmas-example.png" alt="Holiday calendars in oncall example"><figcaption></figcaption></figure>
+## Adding a linked calendar
 
-{% hint style="info" %}
-You can link calendars from Google Calendar, Outlook, or any calendar that provides a public ICS link. You can also upload an `.ics` file directly.
-{% endhint %}
+Visit the [Linked Calendars](https://app.spike.sh/oncalls/linked-calendars) section on your dashboard. You can upload an `.ics` file or link directly from Google Calendar or Outlook.
 
-### Common use cases:
-- Public holiday calendars for your region
-- Company-wide leave calendars from HR systems
-- Shared team calendars for local events or office closures
-
-## Adding a Linked Calendar
-
-You can add calendars from different sources depending on what your team uses. Linked calendars are displayed as overlays on your on-call schedule and can be toggled on or off anytime.
-
-To bring, visit the [Linked Calendars](https://app.spike.sh/oncalls/linked-calendars) section on your dashboard.
-
-<figure><img src="../.gitbook/assets/oncall/linked-calendars/upload-modal.png" alt="Link calendars on Spike.sh"><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/oncall/linked-calendars/upload-modal.png" alt="Link a calendar on Spike"><figcaption><p>Link a calendar from the Linked Calendars section.</p></figcaption></figure>
 
 {% tabs %}
-{% tab title="Upload ICS File" %}
-* **Export your calendar**
-* From your external calendar (Google, Outlook, or others), export your events as an .ics file.
-    * Upload to Spike
-    * In the Linked Calendars section, click + Link a calendar → choose Upload file.
-    * Select your .ics file and click Link.
+{% tab title="Upload ICS file" %}
+1. Export your calendar as a `.ics` file from Google, Outlook, or another calendar app.
+2. In the Linked Calendars section, click **+ Link a calendar** and choose **Upload file**.
+3. Select your `.ics` file and click **Link**.
 
-    The imported calendar will appear as an overlay on your on-call schedule.
-    You can toggle visibility anytime using the checkbox beside its name.
+The imported calendar appears as an overlay. Toggle visibility anytime using the checkbox beside its name.
 {% endtab %}
 {% tab title="Link from Google Calendar" %}
-* **Get the public link**
-    * In Google Calendar, go to **Settings → Integrate calendar**.
-    * Copy the Public address in iCal format.
-    * Your calendar should be public for this to work.
-
-* **Add to Spike**
-    * In the Linked Calendars section, click Link calendar → choose from link and paste the link.
-
-    Spike will automatically fetch updates from the linked calendar. It will also refresh fetch again every 24 hrs at midnight UTC.
-
-    You can toggle visibility and refresh manually anytime.
+1. In Google Calendar, go to **Settings → Integrate calendar**.
+2. Copy the **Public address in iCal format**. The calendar must be set to public.
+3. In the Linked Calendars section, click **Link calendar**, choose **From link**, and paste the link.
 {% endtab %}
 {% tab title="Link from Outlook Calendar" %}
-* **Get the sharing link**
-
-    * In Outlook Calendar, go to **Settings → View all Outlook settings → Calendar → Shared calendars**.
-    * Under Publish a calendar, select the calendar and permissions, then copy the ICS link.
-* **Add to Spike**
-
-    * In the Linked Calendars section, click Link calendar → choose from link and paste teh link.
-
-    Spike will automatically fetch updates from the linked calendar. It will also refresh fetch again every 24 hrs at midnight UTC.
-
-    You can toggle visibility and refresh manually anytime.
+1. In Outlook Calendar, go to **Settings → View all Outlook settings → Calendar → Shared calendars**.
+2. Under **Publish a calendar**, select the calendar and permissions, then copy the ICS link.
+3. In the Linked Calendars section, click **Link calendar**, choose **From link**, and paste the link.
 {% endtab %}
 {% endtabs %}
 
@@ -73,47 +40,37 @@ To bring, visit the [Linked Calendars](https://app.spike.sh/oncalls/linked-calen
 Spike only reads data from linked calendars. It cannot write, modify, or delete any events on external calendars.
 {% endhint %}
 
-## Managing Linked Calendars
+## Managing linked calendars
 
-All linked calendars appear in the [Linked Calendars list](https://app.spike.sh/oncalls/linked-calendars) below your on-call calendar. You can manage their visibility or remove them anytime.
+All linked calendars appear in the [Linked Calendars list](https://app.spike.sh/oncalls/linked-calendars) below your on-call calendar.
 
 - **Toggle on/off:** Use the checkbox beside a calendar name to show or hide it on the on-call view.
+- **Refresh data:** Click **Refresh** beside a calendar to fetch the latest events. Spike refreshes all calendars automatically every 24 hours at midnight UTC.
 
-- **Refresh data:** If a linked calendar is from a public ICS URL, click Refresh to fetch the latest events. Spike refreshes data everyday at 12:00 AM (midnight) in UTC timezone.
-
-**Permissions:** Only users who can modify on-call schedules can add, delete, or manage linked calendars.
+Only users who can modify on-call schedules can add, delete, or manage linked calendars.
 
 {% hint style="info" %}
-Linked calendars are shared across the team. Toggling visibility, adding and deleteing linked calendars affects everyone’s view
+Linked calendars are shared across the team. Toggling visibility, adding, and deleting linked calendars affects everyone's view.
 {% endhint %}
 
 ## FAQs
 
-<details>
-<summary><strong>Can I link multiple calendars?</strong></summary>  
-Yes. You can link multiple calendars such as regional holidays, company events, or shared team calendars.  
-All of them will appear as overlays on your on-call calendar.  
-</details>
+### Can I link multiple calendars?
 
-<details>
-<summary><strong>Does linking a calendar change my on-call schedule?</strong></summary>  
-No. Linked calendars are for reference only and do not modify or offset any on-call shifts.  
-</details>
+Yes. All linked calendars appear as overlays on your on-call calendar.
 
-<details>
-<summary><strong>How often do linked calendars refresh?</strong></summary>  
-Linked calendars added via public links automatically refresh every 24 hours at 12:00 AM, UTC.
-You can also refresh them manually anytime by clicking the **Refresh** option beside the calendar name.  
-</details>
+### Does linking a calendar change my on-call schedule?
 
-<details>
-<summary><strong>Who can add or manage linked calendars?</strong></summary>  
-Anyone with permission to modify on-call schedules can add, delete, or manage linked calendars.  
-These permissions are shared with the on-call configuration access level.  
-</details>
+No. Linked calendars are for reference only and do not modify or offset any on-call shifts.
 
-<details>
-<summary><strong>Can I hide a calendar without deleting it?</strong></summary>  
-Yes. You can toggle visibility on or off using the checkbox beside each calendar.  
-This visibility change applies to everyone in the workspace.  
-</details>
+### How often do linked calendars refresh?
+
+Calendars added via public links refresh automatically every 24 hours at midnight UTC. You can also refresh manually anytime by clicking **Refresh** beside the calendar name.
+
+### Who can add or manage linked calendars?
+
+Anyone with permission to modify on-call schedules can add, delete, or manage linked calendars.
+
+### Can I hide a calendar without deleting it?
+
+Yes. Toggle visibility on or off using the checkbox beside each calendar. The change applies to everyone in the workspace.


### PR DESCRIPTION
## Summary
- Fixed wrong description (copy-pasted from MongoDB integration page)
- Fixed H1 from `# Introduction` to `# Linked calendars`
- Removed "let you" from opener, rewrote as three clean sentences
- Removed redundant `## Common use cases` section (covered by opener)
- Replaced hint block preview of tab options with a plain intro sentence
- Cleaned up tab content: removed nested bullets, converted to flat numbered steps
- Removed duplicate refresh/toggle sentences from Google Calendar and Outlook tabs
- Fixed typos: "teh link", "refresh fetch again", "deleteing"
- Fixed figure caption: "Spike.sh" → "Spike"
- Fixed hint block grammar and missing period
- Converted FAQs from `<details>` to `## FAQs` + `###` headers

## Test plan
- [ ] All three tabs render correctly in GitBook
- [ ] Both images display with captions
- [ ] FAQ headers render as proper H3s
- [ ] Linked Calendars links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)