### PR TITLE
docs: revamp removing team members

### DIFF
--- a/administration/adding-team-members.md
+++ b/administration/adding-team-members.md
@@ -1,17 +1,17 @@
 ---
-description: How to add team members on Spike?
+description: Invite team members to your Spike organisation.
 ---
 
 # Adding team members
 
-Adding team members on Spike is very easy. Click on the **Add team** link on the header to invite your team.
+Click **Add team** in the top navigation to send an invite. Any team member can invite others.
 
-Anyone on Spike.sh can add a team member. Your organisation will also have a **unique invite link** which can be shared with your other teammates to join you.
+Spike also generates a unique invite link for your organisation. Share it with teammates to let them join directly.
 
-![](../.gitbook/assets/invite.png)
+<figure><img src="../.gitbook/assets/invite.png" alt="Invite team members on Spike"><figcaption></figcaption></figure>
 
-### Security with unique link
+## Restrict signups by domain
 
-Signups with your unique link is absolutely safe. For added security, we recommend only allowing signups with emails of your work domain. You can edit the domain in [**settings > organisation**](https://app.spike.sh/settings/general/organisation)****
+Signups via the unique invite link are open to anyone with the link. To restrict access, configure an approved email domain in [Settings > Organisation](https://app.spike.sh/settings/general/organisation). Only members with that domain can then join.
 
-![Configure your domain](../.gitbook/assets/configuring-domains.png)
+<figure><img src="../.gitbook/assets/configuring-domains.png" alt="Configure domain restrictions in Spike organisation settings"><figcaption></figcaption></figure>

--- a/administration/check-if-team-is-getting-alerts.md
+++ b/administration/check-if-team-is-getting-alerts.md
@@ -1,13 +1,13 @@
 ---
-description: Make sure your team members have verified their phone and emails.
+description: Check whether your teammates have verified their phone and email to receive alerts.
 ---
 
-# Check if team is getting alerts
+# Check if your team is getting alerts
 
-It is paramount that your team members have verified their account's phone number and email. As a member or an admin, you can check individual status for each of your team mates status on verification. You can then choose to send a reminder to them as well.
+Team members must verify their phone number and email to receive alerts on those channels. As a member or admin, you can check the verification status of each teammate and send them a reminder if needed.
 
-![Easily send reminders to verify your team member's account](<../.gitbook/assets/remind-users-verification (1).gif>)
+<figure><img src="../.gitbook/assets/remind-users-verification (1).gif" alt="Check teammate verification status and send reminders on Spike"><figcaption></figcaption></figure>
 
 {% hint style="warning" %}
-Note that a team member who has not verified their email and/or phone will not receive alerts on those channels from us
+A team member who has not verified their email or phone will not receive alerts on those channels.
 {% endhint %}

--- a/administration/contact-the-support-team.md
+++ b/administration/contact-the-support-team.md
@@ -1,9 +1,13 @@
+---
+description: Ways to reach Spike's support team.
+---
+
 # Contact the support team
 
-You can reach our support team via multiple mediums.&#x20;
+Spike's support team is available via chat, email, or a scheduled call.
 
-<figure><img src="../.gitbook/assets/chat-support.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/chat-support.png" alt="Spike support chat widget"><figcaption></figcaption></figure>
 
-1. Chat - check for the chat widget on the bottom right part of the screen.&#x20;
-2. Email - you can reach our support team at [support@spike.sh](mailto:support@spike.sh)
-3. Want us to get on a call to help? - schedule one directly from our [calendly](https://calendly.com/spikehq).
+- **Chat:** Use the chat widget in the bottom-right corner of the screen.
+- **Email:** Reach the support team at [support@spike.sh](mailto:support@spike.sh).
+- **Call:** Schedule a call directly on [Calendly](https://calendly.com/spikehq).

--- a/administration/our-notification-numbers.md
+++ b/administration/our-notification-numbers.md
@@ -1,26 +1,27 @@
 ---
-description: List of numbers and emails you will get alerts from.
+description: Add Spike as a contact to receive alerts without interruption. Check whether your country supports calls and SMS.
 ---
 
-# Our notification numbers
+# Notification numbers
 
 ## Bypass Do Not Disturb
 
-Download this vCard and add Spike to your contacts. To bypass **Do Not Distrub** on your phone, add Spike to your favorites.
+Download Spike's contact card and add it to your contacts. To bypass Do Not Disturb on your phone, add Spike to your favorites.
 
-Works with -
+Works with:
 
-1. iOS
-2. Android
-3. All email clients
-4. MacOS
-5. Windows
+- iOS
+- Android
+- All email clients
+- macOS
+- Windows
 
 {% file src="../.gitbook/assets/Spike.sh-contact-card.vcf" %}
-Download our vCard and store our number in favorites
+Download Spike's contact card and save the number to your favorites.
 {% endfile %}
 
-OR Scan below to add Spike as a contact:
-<img src="../.gitbook/assets/administration/qr-code-numbers-download.png" alt="Scan to add Spike as contact" width="400" height="400">
+Or scan the QR code below to add Spike as a contact:
 
-Check if your country/region supports phone calls and SMS [on this page](https://app.spike.sh/geo-permissions).
+<figure><img src="../.gitbook/assets/administration/qr-code-numbers-download.png" alt="Scan to add Spike as contact"><figcaption></figcaption></figure>
+
+Check the [supported countries and regions](https://app.spike.sh/geo-permissions) for phone calls and SMS.

--- a/administration/removing-team-members.md
+++ b/administration/removing-team-members.md
@@ -1,39 +1,35 @@
 ---
-description: >-
-   Admins can safely remove members from their organization’s account. You can optionally reassign the member’s roles in on-call, escalations, and incident response to others.
+description: Remove a team member and handle reassignment of their duties.
 ---
 
 # Removing team members
 
-## How to remove team members?
+Only admins can remove a team member. In [team settings](https://app.spike.sh/settings/general/team), click the remove icon next to the member. Spike shows the number of escalation policies they're part of and any open incidents assigned to them. Once removed, the member stops receiving alerts.
 
-Only admins have the ability to remove a team member. In your [team settings panel](https://app.spike.sh/settings/general/team), you'll find the option to remove any member from your organization. When you remove a member, it may affect the escalation policies they’re part of. You’ll see the number of affected escalations and any open incidents currently assigned to that member. Once removed, the member will no longer receive any alerts.
+## Transfer duties before removing
 
-It is recommended to transfer duties before removing any member to never miss an alert.
+Before removing a member, transfer their responsibilities in on-call schedules, escalation policies, and any incidents they're responding to. This ensures a smooth transition and prevents the removed member from inadvertently going on-call again.
 
-### Transferring duties (recommended)
-When removing a member, it’s important to transfer their responsibilities in on-call schedules, escalations, and incidents they are responding to. This will help with smooth transition, so no alerts are missed and the removed member doesn’t inadvertently go on-call again.
+<figure><img src="../.gitbook/assets/remove-team-members.png" alt="Escalation policies and open incidents assigned to the member being removed"><figcaption></figcaption></figure>
 
-![A snapshot of escalations and current incidents assigned that might get affected](<../.gitbook/assets/remove-team-members.png>)
+## Effect on escalation policies
 
-### How are escalation policies affected?
-
-When a member is removed, they are automatically excluded from all escalation policies they were part of. For example, if an escalation policy sends the first alert to User A and the second alert to User B after 20 minutes, removing User A will result in the policy immediately alerting User B without delay.
+When a member is removed, Spike automatically excludes them from all escalation policies they were part of. For example, if a policy alerts User A first and User B after 20 minutes, removing User A means the policy skips directly to User B without delay.
 
 {% hint style="warning" %}
-If the escalation policy only included this member, that policy will no longer trigger. We recommend you transfer their duties or edit the escalation policy.
+If the escalation policy only included this member, that policy will no longer trigger. Transfer their duties or update the escalation policy before removing them.
 {% endhint %}
 
-### How are assigned open incidents affected?
+## Effect on open incidents
 
-Open incidents are those that remain unresolved. If there are any open incidents assigned to the removed member, we recommend adding another responder or transferring responsibilities during the removal process.
+Open incidents assigned to the removed member remain unassigned. Add another responder or transfer those responsibilities during the removal process.
 
-{% hint style="success" %}
-Billing is adjusted in the next month's cycle. The adjustment is based on the highest number of team members from your organization using Spike.
+{% hint style="info" %}
+Billing is adjusted in the next month's cycle, based on the highest number of team members in your organisation during that period.
 {% endhint %}
 
-## Can I add the same member back again?
+## Can I add the same member back?
 
-Yes, you can add the same member back. However, you will need to re-add them to the relevant escalation policies and reassign any incidents they were handling. [Find removed members here](https://app.spike.sh/settings/general/team/invites-and-deactivated).
+Yes. But you'll need to re-add them to the relevant escalation policies and reassign any incidents they were handling. [Find removed members here](https://app.spike.sh/settings/general/team/invites-and-deactivated).
 
-![Add removed team members](<../.gitbook/assets/activate-user-account.png>)
+<figure><img src="../.gitbook/assets/activate-user-account.png" alt="Reactivate a removed team member on Spike"><figcaption></figcaption></figure>

--- a/administration/roles-and-access.md
+++ b/administration/roles-and-access.md
@@ -1,53 +1,46 @@
 ---
-description: >-
-  Admins can configure roles and permissions minutely at Spike. This doc will
-  guide you through how to create roles and assign different permissions and
-  secure access to critical integrations, on-call p
+description: Manage team roles and permissions to define what each member can do in Spike.
 ---
 
 # Roles and access
 
+Every team member is assigned a role. Each role comes with a predefined set of permissions that admins can edit. Manage roles and access under [Organisation > Team](https://app.spike.sh/settings/general/team).
+
 ## Roles
 
-Checkour roles and access under [Organisation > Team](https://app.spike.sh/settings/general/team). Every member in your team will be assigned a role and every role will have a pre-defined set of permissions that admins can edit.
+By default, four roles are available:
 
-By default, these are the different roles available:
-
-| Role      | Desc                                                                                                    |
+| Role      | Description                                                                                             |
 | --------- | ------------------------------------------------------------------------------------------------------- |
-| Admin     | Admins have full access to manage this account with the added ability to remove people as well          |
-| Manager   | Managers can manage all entities on this account. They can change people's permissions and roles        |
-| Responder | Deals with incidents, integrations, automation, on-calls, etc but they cannot archive/delete any entity |
-| Viewer    | Viewers have read-only permissions across the spectrum on Spike. They can't create, update, or delete   |
+| Admin     | Full access to manage the account, including the ability to remove members                              |
+| Manager   | Can manage all entities on the account and change members' permissions and roles                        |
+| Responder | Can work with incidents, integrations, automation, and on-calls, but cannot archive or delete entities  |
+| Viewer    | Read-only access across Spike. Cannot create, update, or delete anything                                |
 
-![Access control](../.gitbook/assets/access-control-1.png)
+<figure><img src="../.gitbook/assets/access-control-1.png" alt="Roles and access on Spike"><figcaption></figcaption></figure>
 
-Click on the roles above to see who has a given role.
+Click a role to see the members assigned to it.
 
 ## Access control
 
-Access control mainly revolves around who can create, edit, delete or archive integrations, incidents, on-call schedules and so on.
+Access control defines what each team member can do in Spike.
 
-You can click on `View & edit permissions` to see and alter each member's permission.
+Click **View & edit permissions** on any member to see and change their permissions.
 
-![View and edit permissions for users on Spike.sh](../.gitbook/assets/access-control-2.gif)
+<figure><img src="../.gitbook/assets/access-control-2.gif" alt="View and edit permissions for team members on Spike"><figcaption></figcaption></figure>
 
 ## FAQs
 
-### How to edit control for a user?
+### What if no existing role fits a user?
 
-Click on `View & edit permissions` for a user and then change the role for what seems fit.
+Create a custom role. On the Team page, click **Create role**, configure the permissions you need, and assign the new role to the user.
 
-### I don't see a role fit a user, what should I do?
-
-Best to create a new role. Yes, that's possible. On the teams page, click on Create role. In this section, create a new role with whatever permissions you would like to give and then assign the user the newly created role.
-
-![create a new role on Spike.sh](../.gitbook/assets/access-control-create-a-role.png)
+<figure><img src="../.gitbook/assets/access-control-create-a-role.png" alt="Create a custom role on Spike"><figcaption></figcaption></figure>
 
 {% hint style="info" %}
-Status page roles and access works similarly but without the responder role.
+Status pages have their own access settings. The same roles apply, except the Responder role is not available there.
 {% endhint %}
 
 ### How do I remove a user?
 
-Click on the remove icon next to the user's info in the table to remove a user. However, make sure that you replace them from escalation policies and on-call schedules too.
+Click the remove icon next to the user in the table. Make sure to also replace them in any escalation policies and on-call schedules.

--- a/administration/sign-in-rules.md
+++ b/administration/sign-in-rules.md
@@ -1,25 +1,26 @@
 ---
-description: Control sign-in methods and restrict access for better security.  
+description: Control sign-in methods and restrict access by email domain.
 ---
 
-# Sign-In Rules  
+# Sign-in rules
 
-As an admin, you can enforce secure sign-in methods for all members by requiring authentication via **Google** or **SAML SSO** (requires pre-configuration).  
+As an admin, you can enforce authentication via **Google** or **SAML SSO** for all members. SAML SSO requires pre-configuration before it can be enforced.
 
-To configure, visit [Settings > Organisation](https://app.spike.sh/settings/general/organisation).  
+To configure, visit [Settings > Organisation](https://app.spike.sh/settings/general/organisation).
 
-![Sign-In Rules on Spike](../.gitbook/assets/administration/sign-in-rules.png)  
+<figure><img src="../.gitbook/assets/administration/sign-in-rules.png" alt="Sign-in rules on Spike"><figcaption></figcaption></figure>
 
-## Enforce Google or SAML SSO  
+## Enforce Google or SAML SSO
 
-When enabled:  
-- **Google Sign-In:** Users must connect their Google accounts to log in.  
-- **SAML SSO:** Users must authenticate through your identity provider. Access will be restricted otherwise.  
+When enabled:
+
+- **Google Sign-In:** Members must connect their Google accounts to log in.
+- **SAML SSO:** Members must authenticate through your identity provider.
 
 {% hint style="info" %}
-Based on your settings, the invite sign-up page will automatically adjust to display only the allowed sign-in method.  
-{% endhint %}  
+The invite sign-up page automatically shows only the allowed sign-in method.
+{% endhint %}
 
-## Restrict Email Domains  
+## Restrict email domains
 
-Admins can further control access by restricting sign-ins to specific email domains. Once configured, only users with the approved domain(s) can join and log in to Spike.  
+Restrict sign-ins to specific email domains. Once configured, only members with an approved domain can join and log in to Spike.

--- a/administration/sso.md
+++ b/administration/sso.md
@@ -1,72 +1,60 @@
 ---
-description: Configure SAML Single Sign-On on Spike.sh
+description: Configure SAML Single Sign-On (SSO) for your Spike organisation.
 ---
 
-# SSO
+# Single Sign-On (SSO)
 
-This guide explains the settings you’d need to use to configure SAML with your Identity Provider. Once this is set up you should get an XML metadata file which you can provide to Spike.sh and start using SSO. 
+Spike supports SAML SSO for the incident management dashboard and the status page dashboard. Configure SAML with your Identity Provider (IdP), then paste the XML metadata into Spike to activate SSO.
 
-Guides for setting up SAML with other IdPs
+## Set up SAML with your IdP
 
-1. [How to setup SAML on Microsoft Azure AD](https://docs.microsoft.com/en-us/power-apps/maker/portals/configure/configure-saml2-settings-azure-ad)
-2. [How to setup SAML on Google Workspace](https://support.google.com/a/answer/6087519?hl=en)
-3. [How to setup SAML on Onelogin](https://www.onelogin.com/blog/saml-configuration)
-4. [How to setup SAML on Centrify](https://docs.centrify.com/Content/Applications/AppsCustom/AddConfigSAML.htm)
+Guides for common identity providers:
 
-### Step 1
+1. [Set up SAML on Microsoft Azure AD](https://docs.microsoft.com/en-us/power-apps/maker/portals/configure/configure-saml2-settings-azure-ad)
+2. [Set up SAML on Google Workspace](https://support.google.com/a/answer/6087519?hl=en)
+3. [Set up SAML on OneLogin](https://www.onelogin.com/blog/saml-configuration)
+4. [Set up SAML on Centrify](https://docs.centrify.com/Content/Applications/AppsCustom/AddConfigSAML.htm)
 
-Follow the configurations given below while configuring your SAML with your IdP. You can configure SAML SSO for Incident Management and Status Page products individually.
+## Step 1: Configure SAML in your IdP
 
-{% hint style="info" %}
-The below values will be the same for Okta, Microsoft Azure AD, Google, and other IdPs.
-{% endhint %}
+Use the values below when configuring SAML. These values apply to Okta, Microsoft Azure AD, Google, and other providers.
 
-#### For our Incident management dashboard
-* Assertion consumer service URL / Single Sign-On URL / Destination URL: `https://app.spike.sh/sso/oauth/saml`
-* Entity ID / Identifier / Audience URI / Audience Restriction: `https://app.spike.sh`
-* Response: `Signed`
-* Assertion Signature: `Signed`
-* Signature Algorithm: `RSA-SHA256`
-* Assertion Encryption: `Unencrypted`
+### Incident management dashboard
 
-#### For our Status page dashboard
-* Assertion consumer service URL / Single Sign-On URL / Destination URL: `https://statuspage.spike.sh/sso/status-page/oauth/saml`
-* Entity ID / Identifier / Audience URI / Audience Restriction: `https://statuspage.spike.sh`
-* Response: `Signed`
-* Assertion Signature: `Signed`
-* Signature Algorithm: `RSA-SHA256`
-* Assertion Encryption: `Unencrypted`
+- **Assertion consumer service URL / Single Sign-On URL / Destination URL:** `https://app.spike.sh/sso/oauth/saml`
+- **Entity ID / Identifier / Audience URI / Audience Restriction:** `https://app.spike.sh`
+- **Response:** `Signed`
+- **Assertion Signature:** `Signed`
+- **Signature Algorithm:** `RSA-SHA256`
+- **Assertion Encryption:** `Unencrypted`
 
+### Status page dashboard
 
-For example, in the case of Okta users, this is how the configuration looks
+- **Assertion consumer service URL / Single Sign-On URL / Destination URL:** `https://statuspage.spike.sh/sso/status-page/oauth/saml`
+- **Entity ID / Identifier / Audience URI / Audience Restriction:** `https://statuspage.spike.sh`
+- **Response:** `Signed`
+- **Assertion Signature:** `Signed`
+- **Signature Algorithm:** `RSA-SHA256`
+- **Assertion Encryption:** `Unencrypted`
 
-![SAML configurations](<../.gitbook/assets/image (140) (2).png>)
+<figure><img src="../.gitbook/assets/image (140) (2).png" alt="SAML configuration example in Okta"><figcaption><p>Example SAML configuration in Okta.</p></figcaption></figure>
 
-### Step 2
+## Step 2: Add user attribute mappings
 
-Add user mappings as shown below. Note that `email` , `firstName` and `lastName` are mandatory.
+Add the user attribute mappings as shown below. `email`, `firstName`, and `lastName` are required.
 
-![Mappings](<../.gitbook/assets/image (141).png>)
+<figure><img src="../.gitbook/assets/image (141).png" alt="User attribute mappings for SAML SSO"><figcaption></figcaption></figure>
 
+## Step 3: Paste the XML metadata in Spike
 
+Open [organisation settings](https://app.spike.sh/settings/general/organisation), paste the IdP XML metadata, and save.
 
-### Step 3
+<figure><img src="../.gitbook/assets/enter-sso-xml.png" alt="Paste IdP XML metadata in Spike organisation settings"><figcaption></figcaption></figure>
 
-Once the SAML is configured, head over to Spike.sh and open [organisation settings.](https://app.spike.sh/settings/general/organisation)
+## Step 4: Sign in using your organisation slug
 
-Paste the IdP XML Metadata and save.
+Find your organisation slug in [organisation settings](https://app.spike.sh/settings/general/organisation) and use it at the login screen to sign in via SSO.
 
-![Enter sso for spike.sh in settings](<../.gitbook/assets/enter-sso-xml.png>)
+<figure><img src="../.gitbook/assets/sso-slug.png" alt="Organisation slug in Spike settings"><figcaption></figcaption></figure>
 
-
-
-### Step 4
-
-Once configured, you can find the organisation slug from [organisation settings.](https://app.spike.sh/settings/general/organisation)
-
-<img src="../.gitbook/assets/sso-slug.png" alt="" data-size="original">![](<../.gitbook/assets/image (147).png>)
-
-Use that slug at the time of login.&#x20;
-
-
-
+<figure><img src="../.gitbook/assets/image (147).png" alt="SSO login screen with organisation slug"><figcaption></figcaption></figure>

--- a/live-call-routing/introduction-to-live-call-routing.md
+++ b/live-call-routing/introduction-to-live-call-routing.md
@@ -1,208 +1,166 @@
 ---
-description: Live Call Routing, a direct phone line that connects incoming calls to on-call engineers.
+description: Live Call Routing gives your team a phone number that routes incoming calls to the on-call engineer.
 ---
 
-![Live Call Routing](<../.gitbook/assets/live-call-routing/banner-image.png>)
+<figure><img src="../.gitbook/assets/live-call-routing/banner-image.png" alt="Live Call Routing on Spike"><figcaption></figcaption></figure>
 
-# Introduction
+# Live Call Routing
 
-Live Call Routing gives your team a dedicated phone line that instantly connects incoming calls to the right on‑call engineer.  
-It captures human‑reported incidents—like a security vendor reporting a breach or a payment partner flagging a failure—that automated monitors might miss.
+Live Call Routing gives your team a dedicated phone number that routes incoming calls to the on-call engineer. It captures human-reported incidents: a security vendor flagging a breach, or a payment partner reporting a failure. The caller connects directly to whoever is on-call.
 
-Instead of wasting minutes tracking down the right person, the caller reaches the responder on shift within seconds.  
-This closes the gap between automated alerts and real‑world reports, helping your team act faster, reduce downtime, and keep every critical signal from slipping through the cracks.
-
-{%hint style="success%}
+{% hint style="success" %}
 Live Call Routing is available on **all paid plans**.
-{%endhint%}
+{% endhint %}
 
+## How Live Call Routing works
 
+<figure><img src="../.gitbook/assets/live-call-routing/routing-example.png" alt="Live Call Routing flow showing on-call and fallback responders"><figcaption><p>Incoming calls route through on-call and fallback responders.</p></figcaption></figure>
 
----
+Spike uses your on-call schedules to determine who receives calls.
 
-## How Live Call Routing Works
-
-![Routing example](<../.gitbook/assets/live-call-routing/routing-example.png>)
-
-Spike uses your **on‑call schedules** to determine who should receive calls.  
-- An incoming call first rings a configured **on‑call responder**.
-- If there is no answer, it rings **fallback responder**.
-- If still unanswered, it rings **fallback responder 2**.
+- An incoming call first rings the configured on-call responder.
+- If there is no answer, it rings fallback responder 1.
+- If still unanswered, it rings fallback responder 2.
 - If no one answers, Spike plays your configured **No Answer** message and takes a message from the caller.
 
 {% hint style="info" %}
-If a call reaches voicemail, it is treated as a successful connection. Spike cannot detect that the call went to voicemail, so it will not route the call to a fallback responder.
+Voicemail pickup counts as an answered call. Spike will not route to a fallback responder in this case.
 {% endhint %}
 
-Every call is recorded and logged. A detailed alert is sent to your configured **Slack** or **Microsoft Teams** channels.
+Every call is recorded and logged. A detailed alert is sent to your configured Slack or Microsoft Teams channels.
 
-From the call log, you can:
-- Create a new incident 
-- or link the call to an existing incident
-- Save the caller’s number as a contact
+## How to set up Live Call Routing
 
----
+Visit [Live Call Routing](https://app.spike.sh/call-routing) on the dashboard to get started.
 
-## How to set up Live Call Routing?
+Live Call Routing works with any phone number from Twilio or Plivo. Use an existing number you already own, or purchase a new one directly from Twilio or Plivo.
 
-Visit [Live Call Routing](https://app.spike.sh/call-routing) on dashboard to get started. 
+Your number stays completely private. Spike does not require API keys or direct access to your account.
 
-Live Call Routing works with any phone number from **Twilio** or **Plivo**.  
-You can use an existing number you already own, or you can purchase a new number directly from Twilio or Plivo.  
-
-Your number stays completely private. Spike does **not** require API keys or direct access to your account.  
-Instead, Spike gives you a simple **webhook URL**. Paste this webhook into your Twilio or Plivo console so all incoming calls are forwarded to Spike. From there, Spike handles the routing, fallbacks, and call logging for you.
+{% hint style="info" %}
+To get a number directly from Spike, email [support@spike.sh](mailto:support@spike.sh).
+{% endhint %}
 
 {% content-ref url="lcr-with-twilio.md" %} lcr-with-twilio.md {% endcontent-ref %}
 {% content-ref url="lcr-with-plivo.md" %} lcr-with-plivo.md {% endcontent-ref %}
 
-
-> If you would like Spike to provide you with a number, contact us at [support@spike.sh](mailto:support@spike.sh).
-
 {% stepper %}
 {% step %}
-### 1. Add and name your phone number
-   Choose a clear name (e.g., *Engineering Hotline*) and enter your phone number in **full international format**, including the `+` symbol.
+### Add your phone number
 
-   > On Twilio, find your number on **Console → Develop → Phone numbers → Active numbers**.
-   >
-   > On Plivo, you can find your number on **Plivo's console → Numbers → Active**.
+Enter your phone number in full international format, including the `+` symbol. Give it a clear name (e.g., *Engineering Hotline*) for easy identification.
 
-   {%endhint%}
+{% hint style="info" %}
+Find your number in Twilio under **Console → Develop → Phone numbers → Active numbers**, or in Plivo under **Numbers → Active**.
+{% endhint %}
 {% endstep %}
 {% step %}
-### 2. Configure who receives the calls
-Select an on-call schedule or a responder.  
-Optionally add up to **two fallback responders**.
+### Configure who receives the calls
+
+Select an on-call schedule or a specific responder. Optionally add up to two fallback responders.
 {% endstep %}
 {% step %}
-### 3. Customize your messages
-   Set up three audio messages:
-   - **Welcome Message** – played when someone calls.
-   - **No One On‑Call Message** – played if no one is currently on call.
-   - **No Answer Message** – played if all responders fail to answer.
+### Customize your messages
+
+Set up three audio messages:
+- **Welcome message**: played when someone calls.
+- **No one on-call message**: played if no one is currently on call.
+- **No answer message**: played if all responders fail to answer.
 {% endstep %}
 {% step %}
-### 4. Connect your Twilio or Plivo account
-Spike provides a **webhook URL**  
-Paste this webhook into your Twilio or Plivo console as per their instructions.
+### Connect your Twilio or Plivo account
+
+Spike provides a webhook URL. Paste it into your Twilio or Plivo console as per their instructions.
 {% endstep %}
 {% step %}
-### 5. Go Live !
-   Your phone number is now ready to start routing calls.
+### Go live
+
+Your phone number is now ready to start routing calls.
 {% endstep %}
 {% endstepper %}
 
-### Important Note About Call Recordings
+## Call recording setup
 
-When call recording is enabled, Spike retrieves the recordings directly from your Twilio or Plivo account.
-To play these recordings inside Spike, you must turn off **HTTP Basic Authentication for media access** in your provider’s settings.
+When call recording is enabled, Spike retrieves recordings directly from your Twilio or Plivo account. To play recordings inside Spike, disable **HTTP Basic Authentication for media access** in your provider's settings.
 
 {% tabs %}
-{% tab title="Twilio Settings" %}
-In your Twilio Console, go to **Develop → Voice → Settings → General**.  
-Under **HTTP Basic Authentication for media access**, select **Disable**.
+{% tab title="Twilio" %}
+In your Twilio Console, go to **Develop → Voice → Settings → General**. Under **HTTP Basic Authentication for media access**, select **Disable**.
 {% endtab %}
-
-{% tab title="Plivo Settings" %}
-In your Plivo Console, go to **Voice → Settings → Other Settings**.  
-Under **HTTP Basic Authentication for media access**, select **Disable**.
+{% tab title="Plivo" %}
+In your Plivo Console, go to **Voice → Settings → Other Settings**. Under **HTTP Basic Authentication for media access**, select **Disable**.
 {% endtab %}
 {% endtabs %}
 
----
+## Customize messages
 
-## Personalise Messaging
+<figure><img src="../.gitbook/assets/live-call-routing/custom-messaging.png" alt="Custom message configuration for Live Call Routing"><figcaption><p>Configure the three audio messages for your phone line.</p></figcaption></figure>
 
-![Custom messaging](<../.gitbook/assets/live-call-routing/custom-messaging.png>)
+Spike plays audio messages at key points during a call. Configure three types:
 
-You can make every call feel unique by customizing the messages callers hear.  
-Spike lets you set up three types of audio messages, giving you full control over how you greet and guide callers:
+### Welcome message
 
-<details>
-<summary>1. **Welcome Message** </summary>
-Played as soon as the call begins.  
-Use this to greet callers and let them know they’re being connected to your on‑call team.  
-*Example:*
-*“Hi, thanks for calling the Engineering Hotline. Please hold while we connect you to the on‑call engineer.”*
-</details>
-<details>
-<summary>2. **No-one Answered Message** </summary>
-Played when no one answers after trying the primary and fallback responders.  
-You can ask the caller to leave a voicemail after the beep.  
-*Example:*  
-*“Sorry, no one is available to take your call right now. Please leave a message and we’ll get back to you as soon as possible.”*
-</details>
-<details>
-<summary>3. **No-one On‑Call Message** </summary>
-Played when there is no on‑call responder at the moment.  
-You can customize this to explain your schedule or provide next steps, while still letting them leave a message.  
-*Example:*  
-*“Our on‑call team is currently offline. Please leave a message with your name and number, and we’ll return your call as soon as we’re back on shift.”*
-</details>
+Played as soon as the call begins. Use it to greet callers and let them know they're being connected to the on-call team.
 
-These options let you create a professional, branded experience for anyone calling your number—whether it’s during an incident or off‑hours.
+*Example: "Hi, thanks for calling the Engineering Hotline. Please hold while we connect you to the on-call engineer."*
 
----
+### No one answered message
 
-## Call Logs and Recordings
+Played when no one answers after trying the primary and fallback responders. Ask the caller to leave a voicemail after the beep.
 
-![Call Log example](<../.gitbook/assets/live-call-routing/call-log.png>)
+*Example: "Sorry, no one is available to take your call right now. Please leave a message and we'll get back to you as soon as possible."*
 
-All calls appear in the **Call Logs** section of your dashboard.  
-Each log entry includes:
+### No one on-call message
+
+Played when there is no on-call responder at the moment.
+
+*Example: "Our on-call team is currently offline. Please leave a message with your name and number, and we'll return your call as soon as we're back on shift."*
+
+## Call logs and recordings
+
+<figure><img src="../.gitbook/assets/live-call-routing/call-log.png" alt="Call log in Live Call Routing"><figcaption><p>All calls appear in the Call Logs section of your dashboard.</p></figcaption></figure>
+
+All calls appear in the **Call Logs** section of your dashboard. Each log entry includes:
+
 - Caller information
 - Who answered (or if unanswered)
-- Fallback activity (e.g., “Primary did not answer → routed to Secondary”)
+- Fallback activity (e.g., "Primary did not answer → routed to Secondary")
 - Duration of the call
 - A link to the audio recording
 - Detailed activity log
 - Link to incidents
 
-You can:
-- Review the call for post‑incident analysis
+From the log, you can:
+- Review the call for post-incident analysis
 - Create or link incidents directly from the log
 - Archive or delete entries when no longer needed
 
----
+## Test mode
 
-## Test Mode
+Before going live, test your setup:
 
-Before going live, you can test your setup:
+1. Enable **Test Mode** for 5 minutes.
+2. During this time, all calls route directly to you.
+3. Ask a colleague to call your number and confirm that routing, fallback, and messages work as expected.
 
-- Enable **Test Mode** for 5 minutes.  
-- During this time, all calls will route directly to you.
-- Ask a colleague to call your number and confirm that routing, fallback, and messages work as expected.
+## FAQs
 
----
+### How many fallback responders can I add?
 
-## FAQ
+Up to 2 fallback responders.
 
-<details>
-<summary>How many fallback responders can I add?</summary>
-You can add upto 2 fallbacks.
-</details>
+### I don't have a Twilio or Plivo account. How can I get started?
 
-<details>
-<summary>I do not have a Twilio or Plivo account. How can I get started?</summary>
-Our team can help set you up. Please email [support@spike.sh](mailto:support@spike.sh)
-</details>
+Email [support@spike.sh](mailto:support@spike.sh). The Spike team can help with setup.
 
-<details>
-<summary>What happens if no one is on‑call?</summary>
-The caller hears your configured **No One On‑Call Message**, and Spike will take a message for you. A call log will also be created.
-</details>
+### What happens if no one is on-call?
 
-<details>
-<summary>Can I review past calls?</summary>
+The caller hears your configured **No one on-call message**. Spike takes a message and creates a call log.
+
+### Can I review past calls?
+
 Yes. All calls are logged with full details and a recording in the **Call Logs** section.
-</details>
 
-<details>
-<summary>Can I have a transcript on my call?</summary>
-Not yet, sorry!
-</details>
+### Can I have a transcript of my call?
 
----
-
-*If you need help configuring Live Call Routing or integrating your Twilio/Plivo account, reach out to [support@spike.sh](mailto:support@spike.sh).*
+Not yet. Transcripts aren't available currently.

--- a/live-call-routing/lcr-with-plivo.md
+++ b/live-call-routing/lcr-with-plivo.md
@@ -1,59 +1,55 @@
 ---
-description: Learn how to connect your Plivo number with Spike for Live Call Routing
+description: Connect your Plivo number to Spike to enable Live Call Routing.
 ---
-<figure><img src="../.gitbook/assets/live-call-routing/plivo-banner.png" alt=""><figcaption></figcaption></figure>
 
-# Configure Your Plivo Number for Live Call Routing
-During setting up your Live Call Routing in Spike, you’ll receive a unique **webhook URL**. 
+<figure><img src="../.gitbook/assets/live-call-routing/plivo-banner.png" alt="Configure Plivo for Live Call Routing on Spike"><figcaption></figcaption></figure>
 
-Setting up on Plivo is a multi-step process. On Plivo, you'll be needed to create an XML based application that forwaerds request to Spike and then connect it to your phone number.
+# Configure your Plivo number for Live Call Routing
 
-Follow these steps:
+Spike provides a webhook URL during Live Call Routing setup. Plivo requires you to create an XML application first, then connect it to your phone number.
 
 {% stepper %}
 {% step %}
-### Create an Application
+### Create an application
+
 In your Plivo Console, go to **Voice → XML under Applications → New Application**.
 
 Give the application a name you can recognise later.
 
-Under the **Voice** section, select POST request and paste Spike's webhook under
+Under the **Voice** section, select POST request and paste Spike's webhook URL under:
 - Primary answer URL
 - Fallback answer URL
-- and Hangup answer URL *(optional)*
+- Hangup answer URL (optional)
 
-Scroll down and hit **Create Application**
-<figure><img src="../.gitbook/assets/live-call-routing/plivo-settings-1.png" alt=""><figcaption></figcaption></figure>
+Click **Create Application**.
+
+<figure><img src="../.gitbook/assets/live-call-routing/plivo-settings-1.png" alt="Plivo XML application settings for Live Call Routing"><figcaption></figcaption></figure>
 {% endstep %}
 {% step %}
+### Configure your phone number
 
-### Configure Phone number
+Visit **Phone Numbers → Active** and select your number.
 
-Visit **Phone Numbers → Active → Select a Number**.
+In the Number configuration section:
+- Select **XML Application** under Application Type
+- Select your previously created application under **Plivo Application**
 
-In the Number configuration section on the same page, 
-- select **XML Application** under Application Type
-- select your previously created application under **Plivo Application**
+Click **Update**.
 
-and hit Update!
-<figure><img src="../.gitbook/assets/live-call-routing/plivo-settings-2.png" alt=""><figcaption></figcaption></figure>
-
+<figure><img src="../.gitbook/assets/live-call-routing/plivo-settings-2.png" alt="Plivo phone number configuration for Live Call Routing"><figcaption></figcaption></figure>
 {% endstep %}
-
 {% step %}
-### To access call recordings
-   When call recording is enabled, Spike retrieves the recordings directly from your Plivo account.
+### Access call recordings
 
-   - In your Plivo Console, go to **Voice → Settings → Other Settings**.  
-   - Under **HTTP Basic Authentication for media access**, select **Disable**.
+When call recording is enabled, Spike retrieves recordings directly from your Plivo account.
 
+- In your Plivo Console, go to **Voice → Settings → Other Settings**.
+- Under **HTTP Basic Authentication for media access**, select **Disable**.
 {% endstep %}
-
 {% endstepper %}
 
-That’s it. Once saved, your Plivo number will forward all incoming calls to Spike.  
-Spike will handle the routing, fallbacks, and call logging automatically.
+Once saved, your Plivo number will forward all incoming calls to Spike. Spike handles routing, fallbacks, and call logging automatically.
 
----
-
-*If you need help configuring Live Call Routing or integrating your Plivo account, reach out to [support@spike.sh](mailto:support@spike.sh).*
+{% hint style="info" %}
+Need help connecting your Plivo account? Reach out to [support@spike.sh](mailto:support@spike.sh).
+{% endhint %}

--- a/live-call-routing/lcr-with-twilio.md
+++ b/live-call-routing/lcr-with-twilio.md
@@ -1,52 +1,61 @@
 ---
-description: Learn how to connect your Twilio number with Spike for Live Call Routing
+description: Connect your Twilio number to Spike to enable Live Call Routing.
 ---
-<figure><img src="../.gitbook/assets/live-call-routing/twilio-banner.png" alt=""><figcaption></figcaption></figure>
 
-# Configure Your Twilio Number for Live Call Routing
-During setting up your Live Call Routing in Spike, you’ll receive a unique **webhook URL**. 
-Follow these steps to connect it with Twilio:
+<figure><img src="../.gitbook/assets/live-call-routing/twilio-banner.png" alt="Configure Twilio for Live Call Routing on Spike"><figcaption></figcaption></figure>
+
+# Configure your Twilio number for Live Call Routing
+
+Spike provides a webhook URL during Live Call Routing setup. Follow these steps to connect it with your Twilio number.
 
 {% stepper %}
 {% step %}
-### **Sign in to Twilio**  
+### Sign in to Twilio
+
 In your Twilio Console, go to **Develop → Phone Numbers → Manage → Active Numbers**.
-If you don't have a phone number, please buy one on Twilio's dashboard.
+If you don't have a phone number, buy one from the Twilio dashboard first.
 {% endstep %}
 {% step %}
-### **Select your phone number**  
+### Select your phone number
+
 Choose the number you want to use with Live Call Routing.
 {% endstep %}
 {% step %}
-### **Configure incoming call settings**  
-   Scroll down to the **Voice** section.  
-   - For **When a call comes in**, select **Webhook** from the dropdown.  
-   - Paste your **Spike webhook URL** in the field.  
-   - Set the HTTP method to **HTTP POST**.
+### Configure incoming call settings
+
+Scroll down to the **Voice** section.
+
+- For **When a call comes in**, select **Webhook** from the dropdown.
+- Paste your **Spike webhook URL** in the field.
+- Set the HTTP method to **HTTP POST**.
 {% endstep %}
 {% step %}
-### **Configure the fallback handler (optional)**  
-   In the same section, find **If primary handler fails**.  
-   - Select **Webhook** from the dropdown.  
-   - Paste the **same Spike webhook URL**.  
-   - Set the HTTP method to **HTTP POST**.
-   - *Don't forget to save by scrolling down on the same page*
+### Configure the fallback handler (optional)
 
+In the same section, find **If primary handler fails**.
+
+- Select **Webhook** from the dropdown.
+- Paste the **same Spike webhook URL**.
+- Set the HTTP method to **HTTP POST**.
+
+{% hint style="info" %}
+Save your changes by scrolling to the bottom of the page and clicking Save.
+{% endhint %}
 {% endstep %}
 {% step %}
-### 5. **To access call recordings**
-   When call recording is enabled, Spike retrieves the recordings directly from your Twilio account.
+### Access call recordings
 
-   - In your Twilio Console, go to **Develop → Voice → Settings → General**.  
-   - Under **HTTP Basic Authentication for media access**, select **Disable**.
+When call recording is enabled, Spike retrieves recordings directly from your Twilio account.
+
+- In your Twilio Console, go to **Develop → Voice → Settings → General**.
+- Under **HTTP Basic Authentication for media access**, select **Disable**.
 {% endstep %}
 {% endstepper %}
 
-<figure><img src="../.gitbook/assets/live-call-routing/twilio-screenshot-settings.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/live-call-routing/twilio-screenshot-settings.png" alt="Twilio webhook settings for Live Call Routing"><figcaption></figcaption></figure>
 
-That’s it. Once saved, your Twilio number will forward all incoming calls to Spike.  
-Spike will handle the routing, fallbacks, and call logging automatically.
+Once saved, your Twilio number will forward all incoming calls to Spike. Spike handles routing, fallbacks, and call logging automatically.
 
----
-
-*If you need help configuring Live Call Routing or integrating your Twilio account, reach out to [support@spike.sh](mailto:support@spike.sh).*
+{% hint style="info" %}
+Need help connecting your Twilio account? Reach out to [support@spike.sh](mailto:support@spike.sh).
+{% endhint %}

--- a/live-call-routing/triggering-incidents.md
+++ b/live-call-routing/triggering-incidents.md
@@ -2,19 +2,23 @@
 description: Automatically trigger incidents from incoming calls using Live Call Routing.
 ---
 
-![](<../.gitbook/assets/live-call-routing/incidents.png>)
+<figure><img src="../.gitbook/assets/live-call-routing/incidents.png" alt="Triggering incidents from Live Call Routing"><figcaption></figcaption></figure>
 
-# How to Trigger Incidents
+# How to trigger incidents
 
-Spike allows you to manually or automatically trigger incidents from incoming calls using Live Call Routing.
+There are two ways to trigger incidents from Live Call Routing calls: manually from the call log, or automatically after each completed call.
 
-You can:
-- Manually trigger an incident by filling in the title, integration, escalation, and optional fields like priority and severity.
-- Automatically trigger incidents for every call received, based on your configuration.
+## Manual incident creation
 
----
+Open any call in the [call log](https://app.spike.sh/lcr) and click **Create incident**. Fill in:
 
-## Auto-Triggering Incidents
+- **Title**
+- **Integration**
+- **Escalation policy**
+- **Priority** (optional)
+- **Severity** (optional)
+
+## Auto-trigger incidents
 
 You can configure Spike to automatically trigger an incident after each incoming call is completed.
 
@@ -29,15 +33,12 @@ To set up automatic incident creation:
 1. From [Live Call Routing](https://app.spike.sh/lcr), visit **Settings → Incidents**
 2. Enable **Auto-trigger incident for Live Call Routing**
 3. Choose:
-   - The **integration** the incident should be triggered under
-   - The **escalation policy** to be used  
-     > You can choose to default to the escalation policy set on the selected integration. If the policy is updated on the integration later, it will automatically reflect here.
-
+   - The **integration** to use for this incident
+   - The **escalation policy** to use.
+     You can default to the escalation policy set on the selected integration. If the policy is updated on the integration later, the change applies automatically.
 4. (Optional) Set a default **priority** and **severity** to help with alert routing or analytics.
 
----
-
-### Auto-Generated Incident Titles
+## Auto-generated incident titles
 
 Each automatically triggered incident will have a title in this format:
 
@@ -49,9 +50,7 @@ This includes:
 - Phone number
 - Duration of the call
 
----
-
-### Incident Payload Example
+## Incident payload
 
 Spike includes detailed metadata with each auto-triggered incident, so you can automate follow-up actions or run outbound scripts.
 
@@ -91,25 +90,26 @@ Spike includes detailed metadata with each auto-triggered incident, so you can a
 }
 ```
 
-You can use this payload to view who answered or missed the call, Track escalation behavior, Access the call recording, and Run follow-up automation using Spike or external tools.
-
----
+Use this payload to:
+- View who answered or missed the call
+- Track escalation behavior
+- Access the call recording
+- Run follow-up automation using Spike or external tools
 
 ## FAQs
-<details> 
-<summary>Can I trigger incidents for missed calls only?</summary>
+
+### Can I trigger incidents for missed calls only?
+
 Yes.
-</details> 
-<details> 
-<summary>Can I customize the incident title?</summary> 
-Not yet. The incident title is auto-generated using the routing name, caller name/number, and call duration to ensure uniqueness. 
-</details> 
-<details>
-<summary>Will changing the escalation policy on the integration affect auto-triggering?</summary>
-Yes but on ff you’ve selected to `sync escalation with integration`. Any updates to the integration’s escalation will automatically apply here.
-</details>
-<details>
-<details>
-<summary>Can I use this with webhooks or automation tools?</summary>
+
+### Can I customize the incident title?
+
+Not yet. The incident title is auto-generated using the routing name, caller name/number, and call duration to ensure uniqueness.
+
+### Will changing the escalation policy on the integration affect auto-triggering?
+
+Yes, but only if you've selected to sync escalation with the integration. Any updates to the integration's escalation will automatically apply here.
+
+### Can I use this with webhooks or automation tools?
+
 Yes. The incident payload contains detailed metadata (call ID, responder info, timestamps, etc.), which you can use in Spike's outbound webhooks or alert rules.
-</details>

--- a/playbooks/actions-in-playbooks.md
+++ b/playbooks/actions-in-playbooks.md
@@ -1,77 +1,60 @@
 ---
-description: Learn about all the actions you can automate with Playbooks
+description: All actions available in Spike Playbooks, with examples of how to use them.
 ---
 
 # Actions in Playbooks
 
-Playbooks comes up with an ever-growing range of actions to automate your incident response process. Below is a comprehensive list of these actions, each designed to streamline different aspects of your incident response.
+Each Playbook can include one or more of the following actions. Actions run in the order you define.
 
-## List of Actions
+## Actions
 
-1. Add one or more responders
-2. Set priority
-3. Set severity
-4. Change title of an incident with Title remapper
-5. Setup war room (video conference)
-6. Create an issue on JIRA, Linear, or ClickUp
-7. Create a support ticket on Zendesk, Freshdesk, and Supportpal
-8. Trigger external scripts using outbound webhook
-9. Resolve incident(s)
-10. Acknowledge incident(s)
-11. Create an incident on status page and notify subscribers
-12. Resolve an incident on status page
-13. Add links to incident
+- **Add responder** — Add one or more team members to the incident.
+- **Mark priority as** — Set the incident priority from P1 to P5.
+- **Mark severity as** — Set the incident severity from SEV1 to SEV3.
+- **Trigger outbound webhook** — Send the incident payload to an external endpoint to trigger scripts or workflows.
+- **Use Title remapper** — Rewrite the incident title using a predefined template.
+- **Execute playbook** — Trigger another Playbook as part of this one.
+- **Create a War room** — Start a video conference on Google Meet or Zoom for team collaboration.
+- **Create a task on** — Log the incident as a task in Jira, Linear, or ClickUp.
+- **Create a support ticket on** — Open a ticket in Zendesk, Freshdesk, or Supportpal.
+- **Resolve incident** — Mark the incident as resolved.
+- **Acknowledge incident** — Mark the incident as acknowledged.
+- **Add links** — Attach static links to the incident, such as runbooks, PRs, or deploy pipelines.
+- **Create incident on status page** — Publish the incident to your status page and notify subscribers.
+- **Resolve incidents on status page** — Mark the status page incident as resolved.
+- **Resolve by timer after** — Automatically resolve the incident after a set duration.
 
-## Learn more about Playbook actions
+## Examples
 
-1. **Add One or More Responders** Automatically involves team members in the response process, ensuring the right expertise is engaged from the start.
-2. **Set Priority** Assigns a predefined urgency level (P1 to P5) to the incident, helping to prioritize response efforts based on impact and urgency.
-3. **Set Severity** Marks the incident with a severity level (SEV1 to SEV3), indicating the extent of impact and guiding the response strategy.
-4. **Change Title of an Incident with Title Remapper** Utilizes predefined templates or rules to dynamically adjust incident titles for clarity and context.
-5. **Setup War Room (Video Conference)** Initiates a virtual meeting space on supported platforms like Google Meet or Zoom, facilitating immediate team collaboration.
-6. **Create an Issue on JIRA, Linear, or ClickUp** Logs the incident as an issue within popular project management tools, using the incident's title for seamless integration and tracking.
-7. **Create a Support Ticket on Zendesk, Freshdesk, and Supportpal** Opens a ticket in customer support platforms to manage and respond to user-impacting issues effectively.
-8. **Trigger External Scripts Using Outbound Webhook** Executes custom scripts or processes through specified endpoints, enabling integration with external systems or workflows.
-9. **Resolve Incident(s)** Marks incidents as resolved, signaling the successful mitigation or correction of the issue.
-10. **Acknowledge Incident(s)** Indicates that an incident has been noticed and is being addressed, informing team members of ongoing response actions.
-11. **Create an Incident on Status Page and Notify Subscribers** Publicizes the incident on a status page and alerts subscribed users, maintaining transparency and communication with stakeholders.
-12. **Resolve an Incident on Status Page** Updates the status page to reflect the resolution of an incident, informing subscribers and users of the return to normal operations.
-13. **Add links to incident** adds static links to your incident. Use cases include adding internal documentations, Pull requests, Deploy pipelines, customer support, etc.&#x20;
+### Critical incident response
 
-Each of these actions plays a vital role to help you automate as effectively as possible. This will enable your teams to focus on fast resolution and minimizing impact.
+**Conditions:** Payload contains high severity indicators, or the incident has occurred more than `x` times in the last `y` minutes.
 
-## How to use?
+1. Add responder — bring in senior engineers
+2. Mark priority as P1
+3. Mark severity as SEV1
+4. Create a War room — start a Google Meet for immediate discussion
+5. Create a task on Jira — log the incident for tracking
 
-Here are the examples illustrated in the form of actions.
+### Low severity auto-resolution
 
-#### Comprehensive Response to Critical Incidents
+**Conditions:** Payload contains low severity indicators.
 
-**Action 1:** Add one or more responders -- Automatically brings in senior engineering team members. **Action 2:** Set priority -- Assigns the incident a P1 urgency level. **Action 3:** Set severity -- Marks the incident as SEV1. **Action 4:** Setup war room (video conference) -- Creates a Google Meet for immediate discussion. **Action 5:** Create an issue on JIRA -- Logs the incident for tracking and further action.
+1. Mark severity as SEV3
+2. Mark priority as P5
+3. Resolve incident
 
-**Conditions:** Analyze the payload for severity indicators and/or look for number of times an incident has occured in the past `x` minutes.
+### Status page update
 
-#### Automated Low Severity Incidents
+1. Create incident on status page — notify subscribers
+2. Resolve incidents on status page — update subscribers on resolution
 
-**Action 1:** Set severity -- Marks the incident as SEV3, indicating low severity. **Action 2:** Set priority -- Assigns a P5 priority, reflecting lower urgency. **Action 3:** Resolve incidents -- Automatically marks the incident as resolved.
+### Payment system glitch
 
-**Conditions:** Analyse the payload for low severity indicators using specific key/value pairs.
+1. Resolve incident
+2. Create a support ticket on Zendesk — document the issue for customer outreach
 
-#### Automated Status Page Communications
+### Auto-resolve with external trigger
 
-**Action 1:** Create an incident on status page and notify subscribers **Action 2:** Resolve an incident on status page -- Updates subscribers on resolution status.
-
-#### Nudge for Repeated Incident Occurrences
-
-**Action 1:** Set Severity (SEV2) **Action 2:** Create an alert rule to change escalation policy to alert responders.
-
-**Conditions:** If incident has occurred `x number of times in the last y minutes` (_5 times in the last 30 minutes_)
-
-#### Payment System Glitch
-
-**Action 1:** Resolve incident **Action 2:** Auto-create a Support ticket detailing the issue for proactive customer outreach
-
-#### Automated Resolution of Incidents
-
-**Action 1:** Trigger external scripts using outbound webhook -- Initiates custom analysis or alerts external systems for further action. **Action 2:** Resolve the incident
-
-These examples clearly illustrate how Playbooks can be configured to automate responses to a variety of incidents, showcasing the flexibility and power of Playbooks in Spike.sh. By breaking down each response into actionable steps, we demonstrate the practical application of Playbooks in streamlining incident management processes, ensuring teams can respond swiftly and effectively to any situation.
+1. Trigger outbound webhook — run custom analysis or alert external systems
+2. Resolve incident

--- a/playbooks/automating-your-playbooks.md
+++ b/playbooks/automating-your-playbooks.md
@@ -1,57 +1,51 @@
 ---
-description: >-
-  Learn how to set up automated Playbooks so they run without any intervention from users
+description: Set up Playbooks to run automatically when an incident matches conditions you define.
 ---
 
-# Introduction to Automating Playbooks
+# Automating Playbooks
 
-Automating Playbooks empowers teams to handle incidents more effectively by ensuring that predefined actions are run **automatically under certain conditions**. This capability will take a step further in streamlining the incident response process and guarantees consistency in handling incidents, regardless of the time of day or the availability of personnel. Here are a few use cases where automating Playbooks can significantly enhance your incident management workflow:
+Automated Playbooks run on every incident that matches the conditions you define. No manual trigger needed.
 
-By leveraging automation, teams can respond to incidents with the speed and precision required to minimize impact and maintain high levels of service availability and performance.
+## Setting up automation
 
-## Setting Up Automation for Playbooks
+### Step 1: Choose your trigger event
 
-Follow these steps to configure your Playbooks for automation in Spike.sh, making your incident response process more efficient and reliable.
+The trigger is an incoming incident.
 
-### Step 1: Choose Your Trigger Event
+### Step 2: Select integrations and services
 
-Incident Event: Currently, the primary trigger for automating a Playbook is an incident event, such as the creation of a new incident. Future updates will introduce more trigger options, like on-call shift changes.
+Choose whether the automation applies to all integrations and services or only specific ones.
 
-### Step 2: Apply to Integrations or Services
-Selection: Decide whether the automation should apply to all integrations and services on Spike or only specific ones. This choice tailors the Playbook's execution to relevant areas of your operations.
+### Step 3: Define conditions (optional)
 
-### Step 3: Define Conditions (Optional)
-Incident Title: Include keywords or use regular expressions to identify incidents by their titles.
-Incident Details: Specify keywords or regex patterns in incident details, focusing on payload keys and values.
-Incident Occurrences: Trigger the Playbook based on the frequency of an incident within a given timeframe.
-Incident Priority or Severity: Set conditions based on the incident's priority (P1 to P5) or severity (SEV1 to SEV3).
-Conditions can be combined using AND/OR logic for precise control, e.g., "Run Playbook if incident is P1 priority OR contains 'Down' in its title."
+- **Incident title** — match by keyword or regex
+- **Incident details** — match by payload key/value pairs or regex
+- **Incident occurrences** — trigger based on how many times an incident has occurred within a timeframe
+- **Priority or severity** — match by P1–P5 or SEV1–SEV3
 
-### Step 4: Select Incident Status Change Condition
-**Run on Any Incident:** Choose to run the Playbook for any incident status change—triggered, acknowledged, or resolved. This setting ensures the Playbook runs for any incident that matches the conditions from Step 3.
+Combine multiple conditions using AND/OR logic. For example: run the Playbook if the incident is P1 priority OR contains "Down" in its title.
 
-**Run When All Incidents:** Opt to run the Playbook when all incidents in a set reach a certain status, like all being acknowledged or resolved. This approach is useful for coordinated actions across multiple incidents.
+### Step 4: Select incident status condition
 
+**Run on any incident:** Runs for every incident matching your conditions, on any status change — triggered, acknowledged, or resolved.
 
-Once you've configured the trigger, applied the Playbook to the desired integrations or services, and set your conditions, your Playbook is ready to automate. Remember, every Playbook can also be triggered manually, offering flexibility in how you respond to incidents.
+**Run when all incidents:** Runs when all incidents in a set reach a specific status. Useful for coordinated actions across multiple incidents.
 
-## Example use cases for automations
-There are 2 types of use cases here. First when an incident is trigger and second when incidents are all acknowledged or resolved.
+## Example use cases
 
+### When an incident is triggered
 
-### When Any incident is Triggered:
-1. **Automatic service recovery:** Detect a common incident, trigger external scripts via outbound webhook for restarting servers, log diagnostics, run GitHub workflows, resource scaling, backup your dbs, etc. 
-2. **Keyword "Down" Incident:** Automatically detect severity on keyword, alert the teams, and set system updates on your status page. Optionally, create a support ticket on Freshdesk, Zendesk, etc or create a new issue on Linear, JIRA, etc. 
-3. **Critical Integration Incident:** For SEV1 incidents on select integration, set priority P1, launch a War room (video conference), and run external scripts with outbound webhook.
-4. **Customer-Service Outage:** Automaticaly **Acknowledge** incident, create Zendesk ticket, and prepare customer support for communication.
-5. **Service Self-Recovery Attempts:** Auto-Acknowledge or Resolve service restart attempts
-6. **Performance Degrade Alert:** Trigger diagnostics via outbound webhooks and alert relevant teams if performance metrics fall below thresholds.
+1. **Automatic service recovery:** Trigger an outbound webhook to restart servers, run diagnostics, or scale resources.
+2. **Keyword detection:** Detect severity from keywords in the incident title, alert teams, and update your status page.
+3. **Critical integration incident:** For SEV1 incidents on a specific integration, set priority to P1, launch a War room, and run external scripts via outbound webhook.
+4. **Customer-facing outage:** Acknowledge the incident, create a Zendesk ticket, and prepare customer support for communication.
+5. **Service self-recovery:** Auto-acknowledge or resolve incidents triggered by service restart attempts.
+6. **Performance degradation:** Trigger diagnostics via outbound webhook when performance metrics fall below thresholds.
 
-### When one or all incidents are Acknowledged or Resolved:
-1. **Post-Incident Review Initiation**: Trigger an outbound webhook to schedule a review and compile reports once all deployment-related incidents are resolved.
-2. **Automated System Health Rechecks**: After acknowledging connectivity issues, automate a health check to confirm stability. Again, via Outbound webhooks.
-3. **Customer Communication Update**: Automatically update the status page and email resolution summaries to customers when service incidents are resolved.
-4. **Resource Scaling Down**: Initiate resource optimization and scaling down after high-usage incidents are resolved.
-5. **Infrastructure Restoration and Backup Verification**: Automate service restoration and backup checks following database instability resolutions.
+### When incidents are acknowledged or resolved
 
-With the power of automation of Playbooks, the possibilities for streamlining your incident management process are truly endless.
+1. **Post-incident review:** Trigger an outbound webhook to schedule a review once all incidents are resolved.
+2. **System health recheck:** After acknowledging connectivity issues, run an automated health check via outbound webhook.
+3. **Customer communication:** Update the status page and send resolution summaries when incidents are resolved.
+4. **Resource scaling:** Initiate resource optimization after high-usage incidents are resolved.
+5. **Infrastructure restoration:** Automate service restoration and backup checks following database incidents.

--- a/playbooks/introduction-to-playbooks.md
+++ b/playbooks/introduction-to-playbooks.md
@@ -1,59 +1,43 @@
 ---
-description: >-
-  Automate your common actions with Playbooks to reduce mean time to resolution.
+description: Playbooks automate incident response by running predefined actions manually or based on conditions.
 ---
 
 # Playbooks
 
-Get started with Playbooks at [Sidebar > Automation > Playbooks](https://app.spike.sh/automation/playbook)
-
-A Playbook is a powerful tool to automate common actions in your incident management process. It's like a pre-programmed sequence of steps your team should take when specific incidents occur. Instead of scrambling to remember protocols or manually initiating a series of tasks, responders can activate a Playbook with a single click. This triggers a predefined set of actions, such as notifying team members, setting incident severity/priority, or creating support tickets, all tailored to the nature of the incident. 
-
-For added flexibility, Playbooks can be configured to run automatically under certain conditions or for specific incidents, ensuring that your response is both immediate and precisely aligned with your procedures. 
-
-## Simplifying your Incident Management process
-One of the biggest wins with Playbooks is how they make everyone's life easier, especially during crunch time. Let's say something critical goes down. Normally, this would mean a lot of rushing around, messaging people, and trying to remember what needs to be done first. With Playbooks, the heavy lifting is done for you. 
-
-Members can set up a Playbook ahead of time, laying out all the necessary actions like who to alert and add additional responders, and where to document the incident across your task management or support desks. When things hit the fan, anyone on the team can kickstart this process with just one click. 
-
-Playbooks serve as an automated guide, streamlining the execution of all necessary actions promptly and without omission. This approach shortens response times and also shifts the team's focus toward resolving the issue, removing the need for manual coordination and procedure memorization.
-
-## Common Actions with Playbooks
-
-Playbooks can automate a wide range of actions, including but not limited to:
-
-- Adding responders to incidents based on severity or type.
-- Setting incident priorities and severities to align with predefined criteria.
-- Automatically creating communication channels or war rooms for collaboration.
-- Generating tickets in project management or issue tracking systems such as JIRA, Linear, or ClickUp.
-- Initiating support tickets in customer service platforms like Zendesk or Freshdesk.
-- Executing custom scripts or workflows via outbound webhooks for specialized tasks
-
-## How Playbooks function
-
-Playbooks are versatile, capable of functioning in two distinct modes: through manual run and via automatic runs based on specific conditions for select or all integrations/services.
+A Playbook is a sequence of response steps Spike runs on an incident. Set one up once, then trigger it manually or configure it to run automatically.
 
 {% hint style="info" %}
-The sequence of actions in a Playbook is strictly adhered to. Say for example - if you add responders as Step 1, set severity as Step 2, and trigger an outbound webhook as Step 3, these actions will be executed in their precise order.
+Actions run in the exact order you define. Spike does not reorder them.
 {% endhint %}
 
-#### Manual Runs
-Users can manually run a Playbook with the simple click of a button. This feature is particularly useful in situations where a rapid response is required, and the user is aware of the need to initiate a specific set of actions. Upon running, the Playbook carries out its predefined sequence, such as alerting team members, establishing communication channels, and documenting the incident in appropriate systems.
+## What Playbooks can do
 
-#### Automatic Runs
-Playbooks are also designed to run autonomously, executing predetermined actions when certain conditions are satisfied. These conditions could be as specific as the type or severity of an incident being identified. This autonomous operation mode allows Playbooks to function in the background, seamlessly managing your incident responses without demanding immediate manual oversight. This level of automation guarantees both consistency in handling incidents and enables responders to dedicate their focus to resolving the issues at hand.
+- Add responders based on severity or incident type
+- Set incident priority and severity
+- Create war rooms for team collaboration
+- Generate tickets in Jira, Linear, or ClickUp
+- Create support tickets in Zendesk or Freshdesk
+- Trigger external workflows via outbound webhooks
 
+## How Playbooks run
 
-## Who can access it?
+### Manual runs
 
-By default, Playbooks are accessible to all team members, including admins and responders. They can create, edit, and delete Playbooks. However, advanced permission settings that enable teams to customize access levels, granting specific read, write, and execution rights to different roles within the organization.
+Run any Playbook from an incident with a single click. Use this when you need to kick off a response sequence on demand.
 
-Evaluates to True if the total incident occurrences crossed a specific threshold.
+### Automatic runs
 
-## Some Example Use Cases in Brief
-1. **Critical Incident Response:** Automatically gather a response team in a video conference, assign severity, and create an incident ticket.
-2. **Low Severity Management:** For minor issues, set the incident to low priority and resolve it automatically, ensuring focus remains on critical tasks.
-3. **External Communication:** Upon incident detection, create a status page incident and notify subscribers, keeping all stakeholders informed.
-4. **Custom Workflow Integration:** Use outbound webhooks to trigger custom scripts or processes, integrating with external tools or systems for specialized responses.
-5. **High-Volume Ticket Triage:** During peak times when customer support tickets or new incidents surge, a Playbook can categorize tickets based on keywords in incidents, assign them to the appropriate responders, and set priorities.
-6. **Security Breach Detected:** Upon a security incidnet, Acknowledge the incident, generate a high-priority Support ticket for the security team, and trigger security protocols via outbound webhook to isolate.
+Set conditions on a Playbook and Spike runs it automatically on every incident that matches. Conditions can target severity, integration, or other incident properties.
+
+## Permissions
+
+All team members can create, edit, and delete Playbooks by default. Advanced permission settings are available for teams that need granular control over read, write, and execution rights.
+
+## Example use cases
+
+- **Critical incident response:** Add a response team, assign severity, and create a ticket in one click.
+- **Low severity management:** Set the incident to low priority and resolve it automatically.
+- **External communication:** Create a status page incident and notify subscribers automatically.
+- **Custom integrations:** Trigger scripts or external processes via outbound webhooks.
+- **Ticket triage:** Assign incidents to the right responders and set priorities based on keywords.
+- **Security breach:** Acknowledge the incident, open a high-priority support ticket, and trigger isolation protocols via webhook.

--- a/playbooks/run-playbooks-manually.md
+++ b/playbooks/run-playbooks-manually.md
@@ -1,24 +1,23 @@
 ---
-description: >-
-  Playbooks can be run manually by a click of a button with progress on each step's execution
+description: Trigger any Playbook manually from the dashboard or an incident page.
 ---
 
-# Run Playbooks Manually
+# Run Playbooks manually
 
-## User Interaction
+Click the **Playbooks** button on the dashboard or any incident detail page to trigger a Playbook. A progress modal shows the status of each action as it runs.
 
-Users can manually trigger Playbooks directly from the dashboard or any incident detail page. You will find a dedicated "Playbooks" button on each page. When a Playbook is run, a modal will appear to show the progress of each action step by step. 
+## Run on multiple incidents
 
-## Multiple incidents
-A Playbook can be executed for either a single incident or multiple incidents at once. This is handy in case you wish the same response actions across different incidents concurrently.
+A Playbook can run on a single incident or multiple incidents at once. This is useful when you want the same response actions applied across different incidents at the same time.
 
 ## Permissions
-Default settings permit all users to trigger Playbooks, with admin capabilities to adjust access and control execution rights as needed.
 
+All team members can trigger Playbooks by default. Admins can adjust execution rights as needed.
 
-## Customization Before Triggering
-At present, Playbooks do not offer the option for users to customize actions or settings prior to execution. The steps set within a Playbook proceed as predefined without alterations.
+## Customization
 
-## Notifications and Logging
-The manual initiation of a Playbook is logged within Spike.sh for record-keeping; however, no direct notifications are sent out to team members regarding the Playbook run.
+Playbooks run exactly as configured. There is no option to adjust actions at the time of triggering.
 
+## Notifications and logging
+
+Manual Playbook runs are logged in Spike. No notifications are sent to team members when a Playbook is triggered manually.


### PR DESCRIPTION
## Summary
- Updated description: removed "as an admin", tightened wording
- Dropped redundant "How to remove team members?" section header
- Rewrote opener: "have the ability to" → "can", split into shorter sentences, added link to team settings
- Renamed section headers to statement form and made them consistent ("Effect on escalation policies", "Effect on open incidents")
- Rewrote open incidents section to describe the effect first, then the action
- Removed first-person "We recommend" from both hint blocks
- Changed billing hint from success to info style
- Fixed "again" redundancy in FAQ header
- Fixed "Yes." → "Yes. But you'll need to..."
- Converted both images from markdown to <figure> tags with descriptive alt text