### PR TITLE
docs: fix "Broken link" labels in personal-alerts card tables

### DIFF
--- a/alerts/personal-alerts-management/deep-work-and-cooldown-modes.md
+++ b/alerts/personal-alerts-management/deep-work-and-cooldown-modes.md
@@ -59,19 +59,19 @@ You will receive critical incident (SEV1) alerts.
   <tr>
       <td><strong>Resolved incident alerts</strong></td>
       <td>Alerts when incidents are resolved</td>
-      <td><a href="resolved-incident-alerts.md">Broken link</a></td>
+      <td><a href="resolved-incident-alerts.md">Resolved incident alerts</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-resolved-alerts.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
     <tr>
       <td><strong>During office hours</strong></td>
       <td>Custom routing of alerts during office hours</td>
-      <td><a href="during-office-hours.md">Broken link</a></td>
+      <td><a href="during-office-hours.md">During office hours</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
     <tr>
       <td><strong>Out of office</strong></td>
       <td>Step away confidently by scheduling Out of office</td>
-      <td><a href="out-of-office.md">Broken link</a></td>
+      <td><a href="out-of-office.md">Out of office</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
   </tbody>

--- a/alerts/personal-alerts-management/during-office-hours.md
+++ b/alerts/personal-alerts-management/during-office-hours.md
@@ -61,13 +61,13 @@ By default, your office hours are set to Monday through Friday, 9 AM to 5 PM in 
   <tr>
       <td><strong>Resolved incident alerts</strong></td>
       <td>Alerts when incidents are resolved</td>
-      <td><a href="resolved-incident-alerts.md">Broken link</a></td>
+      <td><a href="resolved-incident-alerts.md">Resolved incident alerts</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-resolved-alerts.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
     <tr>
       <td><strong>Out of office</td>
       <td>Step away confidently by scheduling Out of office</strong></td>
-      <td><a href="out-of-office.md">Broken link</a></td>
+      <td><a href="out-of-office.md">Out of office</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
   </tbody>

--- a/alerts/personal-alerts-management/out-of-office.md
+++ b/alerts/personal-alerts-management/out-of-office.md
@@ -48,13 +48,13 @@ Although optional, we recommend offloading your duties to make sure incidents ar
   <tr>
       <td><strong>Resolved incident alerts</strong></td>
       <td>Alerts when incidents are resolved</td>
-      <td><a href="resolved-incident-alerts.md">Broken link</a></td>
+      <td><a href="resolved-incident-alerts.md">Resolved incident alerts</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-resolved-alerts.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
     <tr>
       <td><strong>During office hours</strong></td>
       <td>Custom routing of alerts during office hours</td>
-      <td><a href="during-office-hours.md">Broken link</a></td>
+      <td><a href="during-office-hours.md">During office hours</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
   </tbody>

--- a/alerts/personal-alerts-management/resolved-incident-alerts.md
+++ b/alerts/personal-alerts-management/resolved-incident-alerts.md
@@ -75,13 +75,13 @@ Resolved incident alerts are important, but not critical enough to wake you in t
     <tr>
       <td><strong>During office hours</strong></td>
       <td>Custom routing of alerts during office hours</td>
-      <td><a href="during-office-hours.md">Broken link</a></td>
+      <td><a href="during-office-hours.md">During office hours</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-office-hours.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
     <tr>
       <td><strong>Out of office</strong></td>
       <td>Step away confidently by scheduling Out of office</td>
-      <td><a href="out-of-office.md">Broken link</a></td>
+      <td><a href="out-of-office.md">Out of office</a></td>
       <td><a href="../../.gitbook/assets/personal-alerts-management/thumbnail-out-of-office.png">thumbnail-resolved-alerts.png</a></td>
     </tr>
   </tbody>


### PR DESCRIPTION
## What

The content-ref "Explore" cards on the **Personal alerts management** pages were rendering literal **`Broken link`** as the anchor text — visible on the live docs. Fixed the labels to the correct page titles.

## Why

Stale GitBook export artifact. Every target file exists **and** is present in `SUMMARY.md` nav (`during-office-hours.md`, `out-of-office.md`, `resolved-incident-alerts.md`), so the links themselves were never broken — only the display text was. 9 occurrences across 4 files, label-only change.

## Scope note

`deep-work-and-cooldown-modes.md` is intentionally a deprecated tombstone (its own content states the modes are "deprecated and no longer available", and it's deliberately kept out of `SUMMARY.md` nav), so I left its orphan/nav status untouched and only corrected its card labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)