### PR TITLE
fix: quote description in incident-statuses.md front matter (unblocks GitBook sync)

### DIFF
--- a/incidents/incident-statuses.md
+++ b/incidents/incident-statuses.md
@@ -1,5 +1,5 @@
 ---
-description: Every incident on Spike has one of three statuses: triggered, acknowledged, or resolved. The status determines what Spike does next.
+description: "Every incident on Spike has one of three statuses: triggered, acknowledged, or resolved. The status determines what Spike does next."
 ---
 
 # Incident statuses


### PR DESCRIPTION
## Problem

GitBook sync failed with:

> Failed to parse YAML front matter in `incidents/incident-statuses.md`
> mapping values are not allowed in this context at line 2 column 63

## Cause

The `description` value was unquoted and contained a `: ` sequence:

```yaml
description: Every incident on Spike has one of three statuses: triggered, acknowledged, or resolved. ...
```

Strict YAML parsers read `statuses: triggered` as a nested mapping → parse error.

## Fix

Wrapped the value in double quotes. Also ran a repo-wide YAML parse over every `.md` front matter block — **this was the only file that failed**, so nothing else is queued to break the sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)