### PR TITLE
docs: fix What is Spike page title in SUMMARY.md

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,7 +1,7 @@
 # Table of contents
 
 * [Introduction](README.md)
-* [What is Spike.sh?](what-is-spike.md)
+* [What is Spike?](what-is-spike.md)
 
 ## Incidents
 


### PR DESCRIPTION
## Summary
- Fixed `SUMMARY.md` line 4: `What is Spike.sh?` → `What is Spike?`
- GitBook uses SUMMARY.md for sidebar labels and page titles, which is why the old name was still showing despite the page heading being correct